### PR TITLE
refactor: 리액트쿼리 클라이언트 모듈 분리 및 기본옵션 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './router/router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-const queryClient = new QueryClient();
+import { QueryClientProvider } from '@tanstack/react-query';
+import queryClient from './lib/queryClient';
 
 function App() {
   return (

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,13 @@
+// react query 클라이언트 설정
+
+import { QueryClient } from '@tanstack/react-query';
+
+// 기본 옵션 통일 관리
+export default new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 0,
+    },
+  },
+});

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Navigate } from 'react-router-dom';
 import Main from '@/pages/Main';
 import SpacePage from '@/pages/SpacePage';
 import PanelComponent from '@/pages/componentstest/Panel';
@@ -20,6 +20,10 @@ const router = createBrowserRouter([
     path: '/componentstest',
     element: <ComponentTestPage />,
     children: [
+      {
+        index: true,
+        element: <Navigate to="common" replace />,
+      },
       {
         path: 'common',
         element: <CommonComponent />,


### PR DESCRIPTION
## 작업 내용
- 탭 전환 시 useQuery 기본옵션(refetchOnWindowFocus)으로 인해 API 재요청이 발생했지만, 
MSW가 탭 비활성화 상태에서 일시 정지되었다가 복귀 시점에 요청을 가로채지 못하는 문제가 있었음. 
이에 refetchOnWindowFocus 옵션을 꺼서 불필요한 리패치와 MSW 불일치를 방지함.