### PR TITLE
[리팩토링] galaxy 패널 (community, my) => 레이아웃에 적용

### DIFF
--- a/src/api/galaxy.ts
+++ b/src/api/galaxy.ts
@@ -1,12 +1,28 @@
 import axiosInstance from '@/lib/axios';
-import type { GalaxyListData, ParamsGetGalaxyList } from '@/types/galaxy';
+import type {
+  GalaxyCommunityListData,
+  ParamsGetGalaxyCommunityList,
+} from '@/types/galaxyCommunity';
+import type { GalaxyMyListData, ParamsGetGalaxyMyList } from '@/types/galaxyMy';
 
 export const galaxyAPI = {
   // 갤럭시 목록 조회
-  getGalaxyList: async (params: ParamsGetGalaxyList) => {
-    const response = await axiosInstance.get<GalaxyListData[]>('/galaxies', {
-      params,
-    });
+  getGalaxyCommunityList: async (params: ParamsGetGalaxyCommunityList) => {
+    const response = await axiosInstance.get<GalaxyCommunityListData[]>(
+      '/galaxies/community',
+      {
+        params,
+      }
+    );
+    return response.data;
+  },
+  getGalaxyMyList: async (params: ParamsGetGalaxyMyList) => {
+    const response = await axiosInstance.get<GalaxyMyListData[]>(
+      '/galaxies/my',
+      {
+        params,
+      }
+    );
     return response.data;
   },
 };

--- a/src/components/common/LoadingIcon.tsx
+++ b/src/components/common/LoadingIcon.tsx
@@ -1,0 +1,15 @@
+import { mergeClassNames } from '@/utils/mergeClassNames';
+import { TbLoaderQuarter } from 'react-icons/tb';
+
+export default function LoadingIcon({ className }: { className?: string }) {
+  return (
+    <div
+      className={mergeClassNames(
+        'flex justify-center items-center mt-4 w-full',
+        className
+      )}
+    >
+      <TbLoaderQuarter className="animate-spin" size={20} />
+    </div>
+  );
+}

--- a/src/components/common/SkeletonCard.tsx
+++ b/src/components/common/SkeletonCard.tsx
@@ -5,7 +5,7 @@ function SkeletonCard({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="skeletonCard"
       className={mergeClassNames(
-        'w-full min-w-[223px] bg-gray-card rounded-[8px] p-[17px] border-solid border-[1px] border-gray-border',
+        'w-full min-w-[100px] bg-gray-card rounded-[8px] p-[17px] border-solid border-[1px] border-gray-border',
         'animate-pulse',
         'min-h-[60px]',
         className
@@ -15,6 +15,7 @@ function SkeletonCard({ className, ...props }: React.ComponentProps<'div'>) {
       {/* 스켈레톤 내용물 (옵셔널) */}
       <div className="space-y-2">
         <div className="h-4 bg-gray-600 rounded w-3/4"></div>
+        <div className="h-3 bg-gray-600 rounded w-1/2"></div>
         <div className="h-3 bg-gray-600 rounded w-1/2"></div>
       </div>
     </div>

--- a/src/components/layout/Sidebar/SidebarPanel/MenuContent.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/MenuContent.tsx
@@ -1,5 +1,6 @@
 import type { MenuContent as MenuContentType } from './constants';
 import ProfilePanel from './Profile/ProfilePanel';
+import GalaxyIndex from '@/components/panel/galaxy/GalaxyIndex';
 
 interface MenuContentProps {
   content: MenuContentType;
@@ -14,12 +15,8 @@ export default function MenuContent({ content, menuId }: MenuContentProps) {
         return <ProfilePanel />;
       case 'galaxy':
         return (
-          <div className="space-y-3">
-            <div className="p-3 bg-gray-card rounded-lg">
-              <div className="text-text-white text-sm font-medium">
-                {content.title}
-              </div>
-            </div>
+          <div className="w-full">
+            <GalaxyIndex />
           </div>
         );
       case 'system':

--- a/src/components/layout/Sidebar/SidebarPanel/SidebarPanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/SidebarPanel.tsx
@@ -19,7 +19,7 @@ export default function SecondarySidebar() {
       )}
     >
       {/* 메뉴 내용 */}
-      <div className="flex-1 h-full">
+      <div className="flex-1 h-full overflow-y-auto">
         <MenuContent content={content} menuId={selectedMenu} />
       </div>
     </div>

--- a/src/components/panel/galaxy/GalaxyIndex.tsx
+++ b/src/components/panel/galaxy/GalaxyIndex.tsx
@@ -1,0 +1,27 @@
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/common/Tabs';
+import GalaxyCommunity from './community/GalaxyCommunity';
+import GalaxyMy from './my/GalaxyMy';
+
+export default function GalaxyIndex() {
+  return (
+    <div>
+      <Tabs defaultValue="COMMUNITY" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="COMMUNITY">COMMUNITY</TabsTrigger>
+          <TabsTrigger value="MY">MY</TabsTrigger>
+        </TabsList>
+        <TabsContent value="COMMUNITY" className="p-6">
+          <GalaxyCommunity />
+        </TabsContent>
+        <TabsContent value="MY" className="p-6">
+          <GalaxyMy />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/panel/galaxy/community/CardItem.tsx
+++ b/src/components/panel/galaxy/community/CardItem.tsx
@@ -1,19 +1,19 @@
 import Card from '@/components/common/Card';
-import { GoDotFill } from 'react-icons/go';
+// import { GoDotFill } from 'react-icons/go';
 import ButtonToggleHeart from '@/components/common/ButtonToggleHeart';
 import { IoPlanetOutline } from 'react-icons/io5';
 import { FaRegHeart } from 'react-icons/fa';
-import type { GalaxyListData } from '@/types/galaxy';
+import type { GalaxyCommunityListData } from '@/types/galaxyCommunity';
 
 export default function Item({
   rank,
   galaxyName,
   makerName,
-  createdAt,
+  updatedAt,
   planetCount,
   favoriteCount,
   myFavorite,
-}: GalaxyListData) {
+}: GalaxyCommunityListData) {
   return (
     <Card>
       <div className="flex justify-between items-center">
@@ -26,12 +26,12 @@ export default function Item({
               {galaxyName}
             </strong>
           </div>
-          <div className="flex items-center gap-1 text-[12px] text-text-muted">
+          <div className="mt-3 flex flex-col items-start gap-1 text-[12px] text-text-muted">
             <span>
               BY <span className="text-primary-300">{makerName}</span>
             </span>
-            <GoDotFill />
-            <span>{createdAt}</span>
+            {/* <GoDotFill /> */}
+            <span>{updatedAt}</span>
           </div>
         </div>
         <ButtonToggleHeart className="flex-shrink-0" active={myFavorite} />

--- a/src/components/panel/galaxy/community/GalaxyCommunity.tsx
+++ b/src/components/panel/galaxy/community/GalaxyCommunity.tsx
@@ -1,18 +1,13 @@
-/* 
-  GALAXY - SYSTEMS 다른 사람 항성계 리스트
-  컴포넌트 구조
-  1. SORT
-  2. 은하 리스트
-*/
+// GALAXY > COMMUNITY (다른 사람 항성계 리스트)
 
 import { useState } from 'react';
-import { sortOptions } from '@/types/galaxy';
-import type { SortLabel } from '@/types/galaxy';
+import { sortOptions } from '@/types/galaxyCommunity';
+import type { SortLabel } from '@/types/galaxyCommunity';
 import Sort from './Sort';
 import List from './List';
-import PanelTitle from '../PanelTitle';
+import PanelTitle from '../../PanelTitle';
 
-export default function Index() {
+export default function GalaxyCommunity() {
   const [sort, setSort] = useState<SortLabel>(sortOptions[0].label);
 
   return (

--- a/src/components/panel/galaxy/community/List.tsx
+++ b/src/components/panel/galaxy/community/List.tsx
@@ -1,63 +1,67 @@
 import { Suspense } from 'react';
-import { useGetGalaxyList } from '@/hooks/api/useGalaxy';
-import Item from './Item';
+import { useGetGalaxyCommunityList } from '@/hooks/api/useGalaxy';
+import Item from './CardItem';
 import {
   type SortLabel,
-  type GalaxyListData,
+  type GalaxyCommunityListData,
   toSortValue,
-} from '@/types/galaxy';
+} from '@/types/galaxyCommunity';
 import Button from '@/components/common/Button';
 import { SkeletonCard } from '@/components/common/SkeletonCard';
 import { ErrorBoundary } from 'react-error-boundary';
+import LoadingIcon from '@/components/common/LoadingIcon';
 
 const GALAXY_LIST_LIMIT = 3;
 
 export default function List({ sort }: { sort: SortLabel }) {
   return (
-    <ErrorBoundary FallbackComponent={GalaxyListError}>
-      <Suspense fallback={<GalaxyListLoading />}>
-        <GalaxyListContent sort={sort} />
+    <ErrorBoundary FallbackComponent={ErrorComp}>
+      <Suspense fallback={<LoadingComp />}>
+        <ContentComp sort={sort} />
       </Suspense>
     </ErrorBoundary>
   );
 }
 
 // 갤럭시 리스트 컨텐츠
-function GalaxyListContent({ sort }: { sort: SortLabel }) {
+function ContentComp({ sort }: { sort: SortLabel }) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useGetGalaxyList({
+    useGetGalaxyCommunityList({
       page: 0,
       limit: GALAXY_LIST_LIMIT,
       sort: toSortValue(sort),
     });
 
-  const list: GalaxyListData[] = data?.pages.flat() ?? [];
+  const list: GalaxyCommunityListData[] = data?.pages.flat() ?? [];
 
   return (
     <div>
       {/* 은하 리스트 */}
       <div className="space-y-3">
-        {list.map((galaxySystem: GalaxyListData, index: number) => (
+        {list.map((galaxySystem: GalaxyCommunityListData, index: number) => (
           <Item key={index} {...galaxySystem} />
         ))}
       </div>
-      {isFetchingNextPage && <div>loading more...</div>}
+
       {/* 더보기 버튼 */}
-      {hasNextPage && (
-        <Button
-          className="mt-4 w-full"
-          color="tertiary"
-          onClick={() => fetchNextPage()}
-        >
-          LOAD MORE
-        </Button>
-      )}
+      {hasNextPage &&
+        (isFetchingNextPage ? (
+          <LoadingIcon />
+        ) : (
+          <Button
+            className="mt-4 w-full"
+            color="tertiary"
+            onClick={() => fetchNextPage()}
+          >
+            LOAD MORE
+          </Button>
+        ))}
     </div>
   );
 }
 
 // 로딩 컴포넌트 (3개 스켈레톤)
-function GalaxyListLoading() {
+function LoadingComp() {
   return (
     <div className="space-y-3">
       {Array.from({ length: GALAXY_LIST_LIMIT }).map((_, index) => (
@@ -68,6 +72,6 @@ function GalaxyListLoading() {
 }
 
 // 에러 처리
-function GalaxyListError() {
+function ErrorComp() {
   return <div>Error</div>;
 }

--- a/src/components/panel/galaxy/community/Sort.tsx
+++ b/src/components/panel/galaxy/community/Sort.tsx
@@ -10,8 +10,8 @@ import {
   DropdownMenuRadioItem,
 } from '@/components/common/DropdownMenu';
 import { useState } from 'react';
-import { type SortLabel } from '@/types/galaxy';
-import PanelTitle from '../PanelTitle';
+import { type SortLabel } from '@/types/galaxyCommunity';
+import PanelTitle from '../../PanelTitle';
 
 interface SortProps {
   sortOptions: SortLabel[];
@@ -27,7 +27,7 @@ export default function Sort({ sortOptions, setSort, sort }: SortProps) {
       <PanelTitle>SORT BY</PanelTitle>
       <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
         <DropdownMenuTrigger asChild>
-          <Button color="tertiary" className="w-56" textAlign="left">
+          <Button color="tertiary" className="w-full" textAlign="left">
             {sort}
             <IoMdArrowDropdown
               className={`ml-auto transition-transform duration-200 ${
@@ -36,7 +36,7 @@ export default function Sort({ sortOptions, setSort, sort }: SortProps) {
             />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56">
+        <DropdownMenuContent className="w-[207px]">
           <DropdownMenuRadioGroup
             value={sort}
             onValueChange={(value) => setSort(value as SortLabel)}

--- a/src/components/panel/galaxy/my/CardItem.tsx
+++ b/src/components/panel/galaxy/my/CardItem.tsx
@@ -1,0 +1,41 @@
+import Card from '@/components/common/Card';
+// import { GoDotFill } from 'react-icons/go';
+import ButtonToggleHeart from '@/components/common/ButtonToggleHeart';
+import { IoPlanetOutline } from 'react-icons/io5';
+import { FaRegHeart } from 'react-icons/fa';
+import type { GalaxyMyListData } from '@/types/galaxyMy';
+
+export default function Item({
+  galaxyName,
+  updatedAt,
+  planetCount,
+  favoriteCount,
+}: GalaxyMyListData) {
+  return (
+    <Card>
+      <div className="flex justify-between items-center">
+        <div className="flex-1 min-w-0">
+          <div className="text-[14px] font-bold flex items-center">
+            <strong className="text-white truncate flex-1 min-w-0">
+              {galaxyName}
+            </strong>
+          </div>
+          <div className="mt-3 flex flex-col items-start gap-1 text-[12px] text-text-muted">
+            <span>{updatedAt}</span>
+          </div>
+        </div>
+        <ButtonToggleHeart className="flex-shrink-0" active={false} />
+      </div>
+      <div className="mt-3 flex gap-4">
+        <div>
+          <IoPlanetOutline className="inline-block w-[12px] h-[16px] mr-1" />
+          {planetCount}
+        </div>
+        <div>
+          <FaRegHeart className="inline-block w-[12px] h-[16px] mr-1" />
+          {favoriteCount}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/panel/galaxy/my/CreateNewButton.tsx
+++ b/src/components/panel/galaxy/my/CreateNewButton.tsx
@@ -1,0 +1,17 @@
+import Button from '@/components/common/Button';
+
+export default function CreateNewButton() {
+  const handleCreateNewGalaxy = () => {
+    console.log('새 항성계 생성');
+  };
+
+  return (
+    <Button
+      color="secondary"
+      className="w-full"
+      onClick={handleCreateNewGalaxy}
+    >
+      + CREATE NEW GALAXY
+    </Button>
+  );
+}

--- a/src/components/panel/galaxy/my/GalaxyMy.tsx
+++ b/src/components/panel/galaxy/my/GalaxyMy.tsx
@@ -1,0 +1,20 @@
+// GALAXY > My (내 항성계 리스트)
+
+import List from './List';
+import PanelTitle from '../../PanelTitle';
+import CreateNewButton from './CreateNewButton';
+
+export default function GalaxyMy() {
+  return (
+    <div>
+      {/* 새 항성계 생성 버튼 */}
+      <CreateNewButton />
+
+      {/* 내 항성계 리스트 */}
+      <section className="mt-6">
+        <PanelTitle>MY SYSTEMS</PanelTitle>
+        <List />
+      </section>
+    </div>
+  );
+}

--- a/src/components/panel/galaxy/my/List.tsx
+++ b/src/components/panel/galaxy/my/List.tsx
@@ -1,0 +1,69 @@
+import { Suspense } from 'react';
+import { useGetGalaxyMyList } from '@/hooks/api/useGalaxy';
+import Item from './CardItem';
+import { type GalaxyMyListData } from '@/types/galaxyMy';
+import Button from '@/components/common/Button';
+import { SkeletonCard } from '@/components/common/SkeletonCard';
+import { ErrorBoundary } from 'react-error-boundary';
+
+const GALAXY_LIST_LIMIT = 3;
+
+export default function List() {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorComp}>
+      <Suspense fallback={<LoadingComp />}>
+        <ContentComp />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+// 갤럭시 리스트 컨텐츠
+function ContentComp() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetGalaxyMyList({
+      page: 0,
+      limit: GALAXY_LIST_LIMIT,
+    });
+
+  const list: GalaxyMyListData[] = data?.pages.flat() ?? [];
+
+  return (
+    <div>
+      {/* 은하 리스트 */}
+      <div className="space-y-3">
+        {list.map((galaxySystem: GalaxyMyListData, index: number) => (
+          <Item key={index} {...galaxySystem} />
+        ))}
+      </div>
+      {isFetchingNextPage && <div>loading more...</div>}
+
+      {/* 더보기 버튼 */}
+      {hasNextPage && (
+        <Button
+          className="mt-4 w-full"
+          color="tertiary"
+          onClick={() => fetchNextPage()}
+        >
+          LOAD MORE
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// 로딩 컴포넌트 (3개 스켈레톤)
+function LoadingComp() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: GALAXY_LIST_LIMIT }).map((_, index) => (
+        <SkeletonCard key={index} className="min-h-[110px]" />
+      ))}
+    </div>
+  );
+}
+
+// 에러 처리
+function ErrorComp() {
+  return <div>Error</div>;
+}

--- a/src/hooks/api/useGalaxy.ts
+++ b/src/hooks/api/useGalaxy.ts
@@ -1,17 +1,32 @@
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { galaxyAPI } from '@/api/galaxy';
-import type { ParamsGetGalaxyList } from '@/types/galaxy';
+import type { ParamsGetGalaxyCommunityList } from '@/types/galaxyCommunity';
+import type { ParamsGetGalaxyMyList } from '@/types/galaxyMy';
 
-// 은하 목록 조회
-export function useGetGalaxyList(params: ParamsGetGalaxyList) {
+// Galaxy Community 리스트 조회
+export function useGetGalaxyCommunityList(
+  params: ParamsGetGalaxyCommunityList
+) {
   return useSuspenseInfiniteQuery({
-    queryKey: ['galaxyList', params],
+    queryKey: ['galaxyCommunityList', params],
     queryFn: ({ pageParam }) =>
-      galaxyAPI.getGalaxyList({
+      galaxyAPI.getGalaxyCommunityList({
         page: pageParam,
         limit: params.limit,
         sort: params.sort,
       }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _pages, lastPageParam) =>
+      lastPage.length < params.limit ? undefined : lastPageParam + 1,
+  });
+}
+
+// Galaxy My 리스트 조회
+export function useGetGalaxyMyList(params: ParamsGetGalaxyMyList) {
+  return useSuspenseInfiniteQuery({
+    queryKey: ['galaxyMyList', params],
+    queryFn: ({ pageParam }) =>
+      galaxyAPI.getGalaxyMyList({ page: pageParam, limit: params.limit }),
     initialPageParam: 1,
     getNextPageParam: (lastPage, _pages, lastPageParam) =>
       lastPage.length < params.limit ? undefined : lastPageParam + 1,

--- a/src/mocks/data/galaxiesCommunity.ts
+++ b/src/mocks/data/galaxiesCommunity.ts
@@ -1,12 +1,12 @@
-import type { GalaxyListData } from '@/types/galaxy';
+import type { GalaxyCommunityListData } from '@/types/galaxyCommunity';
 
-// 더미 데이터 : 은하 리스트
-const galaxyDummy: GalaxyListData[] = [
+// 더미 데이터 : Galaxy Community 리스트
+const galaxyDummy: GalaxyCommunityListData[] = [
   {
     rank: 1,
     galaxyName: 'Galaxy 1',
     makerName: 'Maker 1',
-    createdAt: '2021-01-01',
+    updatedAt: '2021-01-01',
     planetCount: 10,
     favoriteCount: 10,
     myFavorite: true,
@@ -15,7 +15,7 @@ const galaxyDummy: GalaxyListData[] = [
     rank: 2,
     galaxyName: 'Galaxy 2',
     makerName: 'Maker 2',
-    createdAt: '2021-01-02',
+    updatedAt: '2021-01-02',
     planetCount: 20,
     favoriteCount: 20,
     myFavorite: false,
@@ -24,16 +24,16 @@ const galaxyDummy: GalaxyListData[] = [
     rank: 3,
     galaxyName: 'Galaxy 3',
     makerName: 'Maker 3',
-    createdAt: '2021-01-03',
+    updatedAt: '2021-01-03',
     planetCount: 30,
     favoriteCount: 30,
     myFavorite: false,
   },
 ];
-const galaxies: GalaxyListData[] = [];
+const galaxiesCommunity: GalaxyCommunityListData[] = [];
 // 3 배로 증식
 for (let i = 0; i < 3; i++) {
-  galaxies.push(...galaxyDummy);
+  galaxiesCommunity.push(...galaxyDummy);
 }
 
-export default galaxies;
+export default galaxiesCommunity;

--- a/src/mocks/data/galaxiesMy.ts
+++ b/src/mocks/data/galaxiesMy.ts
@@ -1,0 +1,30 @@
+import type { GalaxyMyListData } from '@/types/galaxyMy';
+
+// 더미 데이터 : Galaxy My 리스트
+const galaxyDummy: GalaxyMyListData[] = [
+  {
+    galaxyName: 'Galaxy 1',
+    updatedAt: '2021-01-01',
+    planetCount: 10,
+    favoriteCount: 10,
+  },
+  {
+    galaxyName: 'Galaxy 2',
+    updatedAt: '2021-01-02',
+    planetCount: 20,
+    favoriteCount: 20,
+  },
+  {
+    galaxyName: 'Galaxy 3',
+    updatedAt: '2021-01-03',
+    planetCount: 30,
+    favoriteCount: 30,
+  },
+];
+const galaxiesMy: GalaxyMyListData[] = [];
+// 3 배로 증식
+for (let i = 0; i < 3; i++) {
+  galaxiesMy.push(...galaxyDummy);
+}
+
+export default galaxiesMy;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,11 +1,15 @@
 // 핸들러 : 요청을 가로채고 어떤 응답을 줄지 정의한다.
-import galaxies from './data/galaxies';
+import galaxiesCommunity from './data/galaxiesCommunity';
+import galaxiesMy from './data/galaxiesMy';
 import { planet, planets, star } from './data/system';
 import { mockFetch, mockFetchInfinite } from './utils';
 
 export const handlers = [
-  // galaxy 은하 목록 조회 (infinite)
-  mockFetchInfinite('/galaxies', galaxies, 2000),
+  // galaxy Community 리스트트 조회 (infinite)
+  mockFetchInfinite('/galaxies/community', galaxiesCommunity, 2000),
+
+  // galaxy My 리스트트 조회 (infinite)
+  mockFetchInfinite('/galaxies/my', galaxiesMy, 2000),
 
   // system 별 개별 정보 조회
   mockFetch('/systems/:galaxyId/star', star, 2000),

--- a/src/pages/componentstest/Panel.tsx
+++ b/src/pages/componentstest/Panel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Info from '@/components/panel/system/info/Info';
-import GalaxyIndex from '@/components/panel/galaxy/Index';
+import GalaxyIndex from '@/components/panel/galaxy/GalaxyIndex';
 import PlanetsIndex from '@/components/panel/system/planets/Index';
 import PropertiesIndex from '@/components/panel/system/properties/Index';
 

--- a/src/types/galaxyCommunity.ts
+++ b/src/types/galaxyCommunity.ts
@@ -1,16 +1,16 @@
 // 은하 목록 데이터
-export interface GalaxyListData {
+export interface GalaxyCommunityListData {
   rank: number;
   galaxyName: string;
   makerName: string;
-  createdAt: string;
+  updatedAt: string;
   planetCount: number;
   favoriteCount: number;
   myFavorite: boolean;
 }
 
 // 은하 목록 조회 파라미터
-export interface ParamsGetGalaxyList {
+export interface ParamsGetGalaxyCommunityList {
   page: number;
   limit: number;
   sort: string;

--- a/src/types/galaxyMy.ts
+++ b/src/types/galaxyMy.ts
@@ -1,0 +1,13 @@
+// 내 항성계 목록 데이터
+export interface GalaxyMyListData {
+  galaxyName: string;
+  updatedAt: string;
+  planetCount: number;
+  favoriteCount: number;
+}
+
+// 내 항성계 목록 조회 파라미터
+export interface ParamsGetGalaxyMyList {
+  page: number;
+  limit: number;
+}


### PR DESCRIPTION
## 작업 내용
- Galaxy 패널을 Community / My 탭으로 분리
- 각 탭별로 데이터 소스, 타입, 컴포넌트 분리
- API, hooks, mocks, UI 구조 업데이트
- 각 탭 전용 파일, 타입, mock 데이터 추가
- Sidebar 및 관련 컴포넌트를 새 GalaxyIndex 엔트리 포인트로 연결

## 참고 사항
- 기존 단일 Galaxy 패널 구조는 제거되었으며, 모든 접근은 GalaxyIndex 기준으로 변경됨
- 이후 탭별 확장(필터, 정렬 등) 시에도 독립적으로 구현 가능