### PR TITLE
[리팩토링] galaxy 리스트 컴포넌트 함수 내부 수정 및 갤럭시 리스트 React Query 훅 queryKey 수정

### DIFF
--- a/src/components/panel/galaxy/community/CardItem.tsx
+++ b/src/components/panel/galaxy/community/CardItem.tsx
@@ -1,11 +1,10 @@
 import Card from '@/components/common/Card';
-// import { GoDotFill } from 'react-icons/go';
 import ButtonToggleHeart from '@/components/common/ButtonToggleHeart';
 import { IoPlanetOutline } from 'react-icons/io5';
 import { FaRegHeart } from 'react-icons/fa';
 import type { GalaxyCommunityListData } from '@/types/galaxyCommunity';
 
-export default function Item({
+export default function CardItem({
   rank,
   galaxyName,
   makerName,
@@ -30,7 +29,6 @@ export default function Item({
             <span>
               BY <span className="text-primary-300">{makerName}</span>
             </span>
-            {/* <GoDotFill /> */}
             <span>{updatedAt}</span>
           </div>
         </div>

--- a/src/components/panel/galaxy/community/List.tsx
+++ b/src/components/panel/galaxy/community/List.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { useGetGalaxyCommunityList } from '@/hooks/api/useGalaxy';
-import Item from './CardItem';
+import CardItem from './CardItem';
 import {
   type SortLabel,
   type GalaxyCommunityListData,
@@ -38,8 +38,8 @@ function ContentComp({ sort }: { sort: SortLabel }) {
     <div>
       {/* 은하 리스트 */}
       <div className="space-y-3">
-        {list.map((galaxySystem: GalaxyCommunityListData, index: number) => (
-          <Item key={index} {...galaxySystem} />
+        {list.map((galaxySystem: GalaxyCommunityListData) => (
+          <CardItem key={galaxySystem.galaxyName} {...galaxySystem} />
         ))}
       </div>
 

--- a/src/components/panel/galaxy/my/CardItem.tsx
+++ b/src/components/panel/galaxy/my/CardItem.tsx
@@ -1,11 +1,9 @@
 import Card from '@/components/common/Card';
-// import { GoDotFill } from 'react-icons/go';
-import ButtonToggleHeart from '@/components/common/ButtonToggleHeart';
 import { IoPlanetOutline } from 'react-icons/io5';
 import { FaRegHeart } from 'react-icons/fa';
 import type { GalaxyMyListData } from '@/types/galaxyMy';
 
-export default function Item({
+export default function CardItem({
   galaxyName,
   updatedAt,
   planetCount,
@@ -24,7 +22,6 @@ export default function Item({
             <span>{updatedAt}</span>
           </div>
         </div>
-        <ButtonToggleHeart className="flex-shrink-0" active={false} />
       </div>
       <div className="mt-3 flex gap-4">
         <div>

--- a/src/components/panel/galaxy/my/List.tsx
+++ b/src/components/panel/galaxy/my/List.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from 'react';
 import { useGetGalaxyMyList } from '@/hooks/api/useGalaxy';
-import Item from './CardItem';
+import CardItem from './CardItem';
 import { type GalaxyMyListData } from '@/types/galaxyMy';
 import Button from '@/components/common/Button';
 import { SkeletonCard } from '@/components/common/SkeletonCard';
 import { ErrorBoundary } from 'react-error-boundary';
+import LoadingIcon from '@/components/common/LoadingIcon';
 
 const GALAXY_LIST_LIMIT = 3;
 
@@ -32,22 +33,25 @@ function ContentComp() {
     <div>
       {/* 은하 리스트 */}
       <div className="space-y-3">
-        {list.map((galaxySystem: GalaxyMyListData, index: number) => (
-          <Item key={index} {...galaxySystem} />
+        {list.map((galaxySystem: GalaxyMyListData) => (
+          <CardItem key={galaxySystem.galaxyName} {...galaxySystem} />
         ))}
       </div>
       {isFetchingNextPage && <div>loading more...</div>}
 
       {/* 더보기 버튼 */}
-      {hasNextPage && (
-        <Button
-          className="mt-4 w-full"
-          color="tertiary"
-          onClick={() => fetchNextPage()}
-        >
-          LOAD MORE
-        </Button>
-      )}
+      {hasNextPage &&
+        (isFetchingNextPage ? (
+          <LoadingIcon />
+        ) : (
+          <Button
+            className="mt-4 w-full"
+            color="tertiary"
+            onClick={() => fetchNextPage()}
+          >
+            LOAD MORE
+          </Button>
+        ))}
     </div>
   );
 }

--- a/src/hooks/api/useGalaxy.ts
+++ b/src/hooks/api/useGalaxy.ts
@@ -8,7 +8,10 @@ export function useGetGalaxyCommunityList(
   params: ParamsGetGalaxyCommunityList
 ) {
   return useSuspenseInfiniteQuery({
-    queryKey: ['galaxyCommunityList', params],
+    queryKey: [
+      'galaxyCommunityList',
+      { limit: params.limit, sort: params.sort },
+    ],
     queryFn: ({ pageParam }) =>
       galaxyAPI.getGalaxyCommunityList({
         page: pageParam,
@@ -24,7 +27,7 @@ export function useGetGalaxyCommunityList(
 // Galaxy My 리스트 조회
 export function useGetGalaxyMyList(params: ParamsGetGalaxyMyList) {
   return useSuspenseInfiniteQuery({
-    queryKey: ['galaxyMyList', params],
+    queryKey: ['galaxyMyList', { limit: params.limit }],
     queryFn: ({ pageParam }) =>
       galaxyAPI.getGalaxyMyList({ page: pageParam, limit: params.limit }),
     initialPageParam: 1,


### PR DESCRIPTION
## 작업 내용
- Item 컴포넌트를 CardItem으로 이름 변경하여 Community, My Galaxy 패널에서 명확성 확보
- 리스트 렌더링 시 key를 index에서 galaxyName으로 변경
- My Galaxy 리스트에서 로딩 상태 개선 (LoadingIcon 추가)
- useGalaxy 훅에서 더 구체적인 query key 사용으로 불필요한 캐시 무효화 감소

## 참고 사항
- query key 구조 변경으로 캐시 동작 방식이 일부 달라질 수 있음