### PR TITLE
[기능] 패널 관련 리팩토링 및 좋아요 패널 레이아웃 구현

### DIFF
--- a/src/components/layout/Sidebar/SidebarPanel/Profile/FollowersPanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/FollowersPanel.tsx
@@ -1,0 +1,27 @@
+import { FiUser } from 'react-icons/fi';
+import { useSidebarStore } from '@/stores/sidebarStore';
+import PanelHeader from '../PanelHeader';
+import Card from '@/components/common/Card';
+import Iconframe from '@/components/common/Iconframe';
+
+export default function FollowersPanel() {
+  const { setProfilePanelMode } = useSidebarStore();
+
+  // 임시 데이터
+  const followers = [
+    { id: 1, username: 'Follower1', joinDate: '2024-01-15' },
+    { id: 2, username: 'Follower2', joinDate: '2024-02-20' },
+    { id: 3, username: 'Follower3', joinDate: '2024-03-10' },
+  ];
+
+  return (
+    <>
+      <PanelHeader
+        title="FOLLOWERS"
+        showBackButton={true}
+        onBack={() => setProfilePanelMode('profile')}
+      />
+      <div className="flex flex-col p-4 h-full overflow-hidden"></div>
+    </>
+  );
+}

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/FollowingsPanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/FollowingsPanel.tsx
@@ -1,0 +1,27 @@
+import { FiUserCheck } from 'react-icons/fi';
+import { useSidebarStore } from '@/stores/sidebarStore';
+import PanelHeader from '../PanelHeader';
+import Card from '@/components/common/Card';
+import Iconframe from '@/components/common/Iconframe';
+
+export default function FollowingsPanel() {
+  const { setProfilePanelMode } = useSidebarStore();
+
+  // 임시 데이터
+  const followings = [
+    { id: 1, username: 'Following1', joinDate: '2024-01-10' },
+    { id: 2, username: 'Following2', joinDate: '2024-02-15' },
+    { id: 3, username: 'Following3', joinDate: '2024-03-05' },
+  ];
+
+  return (
+    <>
+      <PanelHeader
+        title="FOLLOWINGS"
+        showBackButton={true}
+        onBack={() => setProfilePanelMode('profile')}
+      />
+      <div className="flex flex-col p-4 h-full overflow-hidden"></div>
+    </>
+  );
+}

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/LikesPanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/LikesPanel.tsx
@@ -1,0 +1,26 @@
+import { FiHeart } from 'react-icons/fi';
+import { useSidebarStore } from '@/stores/sidebarStore';
+import PanelHeader from '../PanelHeader';
+import Card from '@/components/common/Card';
+
+export default function LikesPanel() {
+  const { setProfilePanelMode } = useSidebarStore();
+
+  // 임시 데이터
+  const likedItems = [
+    { id: 1, name: 'Galaxy Alpha', type: 'Galaxy', author: 'User1' },
+    { id: 2, name: 'Solar System Beta', type: 'System', author: 'User2' },
+    { id: 3, name: 'Planet Gamma', type: 'Planet', author: 'User3' },
+  ];
+
+  return (
+    <>
+      <PanelHeader
+        title="MY LIKES"
+        showBackButton={true}
+        onBack={() => setProfilePanelMode('profile')}
+      />
+      <div className="flex flex-col p-4 h-full overflow-hidden"></div>
+    </>
+  );
+}

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/LikesPanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/LikesPanel.tsx
@@ -1,16 +1,50 @@
-import { FiHeart } from 'react-icons/fi';
 import { useSidebarStore } from '@/stores/sidebarStore';
 import PanelHeader from '../PanelHeader';
-import Card from '@/components/common/Card';
+import CardItem from '@/components/panel/galaxy/community/CardItem';
+import { ScrollArea } from '@/components/common/Scrollarea';
+import type { GalaxyCommunityListData } from '@/types/galaxyCommunity';
 
 export default function LikesPanel() {
   const { setProfilePanelMode } = useSidebarStore();
 
-  // 임시 데이터
-  const likedItems = [
-    { id: 1, name: 'Galaxy Alpha', type: 'Galaxy', author: 'User1' },
-    { id: 2, name: 'Solar System Beta', type: 'System', author: 'User2' },
-    { id: 3, name: 'Planet Gamma', type: 'Planet', author: 'User3' },
+  // 임시 데이터 - GalaxyCommunityListData 타입에 맞게 수정
+  const likedItems: GalaxyCommunityListData[] = [
+    {
+      rank: 1,
+      galaxyName: 'galaxy1',
+      makerName: 'User1',
+      updatedAt: '2 days ago',
+      planetCount: 5,
+      favoriteCount: 24,
+      myFavorite: true,
+    },
+    {
+      rank: 2,
+      galaxyName: 'galaxy2',
+      makerName: 'User2',
+      updatedAt: '1 week ago',
+      planetCount: 3,
+      favoriteCount: 18,
+      myFavorite: true,
+    },
+    {
+      rank: 3,
+      galaxyName: 'galaxy3',
+      makerName: 'User3',
+      updatedAt: '3 days ago',
+      planetCount: 7,
+      favoriteCount: 32,
+      myFavorite: true,
+    },
+    {
+      rank: 4,
+      galaxyName: 'galaxy4',
+      makerName: 'User4',
+      updatedAt: '5 days ago',
+      planetCount: 4,
+      favoriteCount: 15,
+      myFavorite: true,
+    },
   ];
 
   return (
@@ -20,7 +54,20 @@ export default function LikesPanel() {
         showBackButton={true}
         onBack={() => setProfilePanelMode('profile')}
       />
-      <div className="flex flex-col p-4 h-full overflow-hidden"></div>
+      <div className="flex flex-col h-full overflow-hidden">
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="p-4">
+            <p className="text-text-muted text-sm font-semibold mb-[16px]">
+              TOTAL LIKES ({likedItems.length})
+            </p>
+            <div className="space-y-3">
+              {likedItems.map((item) => (
+                <CardItem key={item.galaxyName} {...item} />
+              ))}
+            </div>
+          </div>
+        </ScrollArea>
+      </div>
     </>
   );
 }

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/LoginPanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/LoginPanel.tsx
@@ -1,0 +1,64 @@
+import { FiUser } from 'react-icons/fi';
+import { useSidebarStore } from '@/stores/sidebarStore';
+import Iconframe from '@/components/common/Iconframe';
+import TextInput from '@/components/common/TextInput';
+import Button from '@/components/common/Button';
+import TextField from '@/components/common/textField';
+
+export default function LoginPanel() {
+  const { setProfilePanelMode } = useSidebarStore();
+
+  return (
+    <div className="text-center p-4">
+      <div className="flex flex-col items-center mb-[24px]">
+        <Iconframe color="primary" size="medium" className="mb-[16px]">
+          <FiUser />
+        </Iconframe>
+        <h3 className="text-white font-semibold text-base">WELCOME BACK</h3>
+        <p className="text-text-muted text-sm">
+          SIGN IN TO CREATE AND
+          <br />
+          MANAGE SYSTEMS
+        </p>
+      </div>
+      <div className="flex flex-col mt-[24px] text-left gap-[16px]">
+        <TextField label="Email" htmlFor="email">
+          <TextInput type="email" placeholder="Enter your email" id="email" />
+        </TextField>
+        <TextField label="Password" htmlFor="password">
+          <TextInput
+            type="password"
+            placeholder="Enter your password"
+            id="password"
+          />
+        </TextField>
+      </div>
+      <Button color="primary" size="lg" className="w-full mt-[24px]">
+        SIGN IN
+      </Button>
+      <div className="flex justify-center mt-[24px] mb-[24px]">
+        <a
+          href="#"
+          className="text-primary-300 text-xs hover:text-primary-200 transition-colors cursor-pointer"
+        >
+          FORGOT PASSWORD?
+        </a>
+      </div>
+      <div className="flex flex-col items-center border-t border-gray-border pt-[24px]">
+        <p className="text-text-muted text-xs mb-[8px]">
+          DON'T HAVE AN ACCOUNT?
+        </p>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            setProfilePanelMode('signup');
+          }}
+          className="text-primary-300 text-sm font-semibold hover:text-primary-200 transition-colors cursor-pointer"
+        >
+          SIGN UP
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/ProfilePanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/ProfilePanel.tsx
@@ -1,186 +1,41 @@
-import {
-  FiEdit3,
-  FiUser,
-  FiLogOut,
-  FiChevronRight,
-  FiHeart,
-  FiUserCheck,
-} from 'react-icons/fi';
-import { IoPlanetOutline } from 'react-icons/io5';
 import { useSidebarStore } from '@/stores/sidebarStore';
-import Iconframe from '@/components/common/Iconframe';
-import TextInput from '@/components/common/TextInput';
-import Button from '@/components/common/Button';
-import TextField from '@/components/common/textField';
+import LoginPanel from './LoginPanel';
 import SignUpPanel from './SignUpPanel';
-import Card from '@/components/common/Card';
+import ProfileView from './ProfileView';
+import LikesPanel from './LikesPanel';
+import FollowersPanel from './FollowersPanel';
+import FollowingsPanel from './FollowingsPanel';
 
 export default function ProfilePanel() {
-  const { isLoggedIn, profilePanelMode, setProfilePanelMode } =
-    useSidebarStore();
+  const { isLoggedIn, profilePanelMode } = useSidebarStore();
 
-  // 임시 데이터
-  const profile = {
-    username: '테스터',
-    email: 'tester@example.com',
-    joinDate: '2024-01-01',
-    about: 'aboutaboutabout',
+  const renderContent = () => {
+    if (!isLoggedIn) {
+      // 로그인되지 않은 상태
+      switch (profilePanelMode) {
+        case 'signup':
+          return <SignUpPanel />;
+        default:
+          return <LoginPanel />;
+      }
+    }
+
+    // 로그인된 상태
+    switch (profilePanelMode) {
+      case 'likes':
+        return <LikesPanel />;
+      case 'followers':
+        return <FollowersPanel />;
+      case 'followings':
+        return <FollowingsPanel />;
+      default:
+        return <ProfileView />;
+    }
   };
 
   return (
-    <div className={'h-full flex flex-col overflow-hidden'}>
-      {isLoggedIn ? (
-        // 로그인된 상태 - 프로필 화면
-        <>
-          <div className="flex flex-col h-full overflow-hidden">
-            <div className="flex flex-col items-center border-b border-gray-border p-6">
-              <div className="flex flex-col items-center mb-[24px]">
-                <Iconframe color="tertiary" size="large" className="mb-[16px]">
-                  <FiUser />
-                </Iconframe>
-                <h3 className="text-white font-semibold text-base">
-                  {profile.username}
-                </h3>
-                <p className="text-text-muted text-sm text-center">
-                  {profile.about}
-                </p>
-              </div>
-              <Button color="secondary" size="lg" className="w-full">
-                <FiEdit3 />
-                EDIT PROFILE
-              </Button>
-            </div>
-            <div className="flex flex-col p-6 flex-1">
-              <p className="text-tertiary-200 text-sm font-semibold mb-[16px]">
-                STATISTICS
-              </p>
-              <div className="mb-[24px]">
-                <p className="text-text-muted text-sm mb-[16px]">
-                  STELLAR SYSTEMS
-                </p>
-                <Card>
-                  <div className="flex items-center justify-center gap-2 mb-[16px]">
-                    <IoPlanetOutline className="text-tertiary-300 text-lg" />
-                    <p className="text-text-muted text-sm">CREATED</p>
-                  </div>
-                  <p className="text-white text-center text-[24px] font-semibold">
-                    3
-                  </p>
-                </Card>
-              </div>
-              <div className="mb-[24px]">
-                <p className="text-text-muted text-sm mb-[16px]">LIKES</p>
-                <Card>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center">
-                      <FiHeart className="text-white text-lg mr-4" />
-                      <div className="flex flex-col">
-                        <p className="text-white text-lg font-semibold">85</p>
-                        <p className="text-text-muted text-sm">MY LIKES</p>
-                      </div>
-                    </div>
-                    <FiChevronRight className="text-text-muted text-lg" />
-                  </div>
-                </Card>
-              </div>
-              <div className="mb-[24px]">
-                <p className="text-text-muted text-sm mb-[16px]">SOCIALS</p>
-                <div className="flex flex-col gap-[12px] w-full">
-                  <Card>
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center">
-                        <FiUser className="text-primary-300 text-lg mr-4" />
-                        <div className="flex flex-col">
-                          <p className="text-white text-lg font-semibold">24</p>
-                          <p className="text-text-muted text-sm">FOLLOWERS</p>
-                        </div>
-                      </div>
-                      <FiChevronRight className="text-text-muted text-lg" />
-                    </div>
-                  </Card>
-                  <Card>
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center">
-                        <FiUserCheck className="text-secondary-300 text-lg mr-4" />
-                        <div className="flex flex-col">
-                          <p className="text-white text-lg font-semibold">18</p>
-                          <p className="text-text-muted text-sm">FOLLOWINGS</p>
-                        </div>
-                      </div>
-                      <FiChevronRight className="text-text-muted text-lg" />
-                    </div>
-                  </Card>
-                </div>
-              </div>
-            </div>
-            <div className="p-6 border-t border-gray-border">
-              <Button color="tertiary" size="lg" className="w-full">
-                <FiLogOut />
-                SIGN OUT
-              </Button>
-            </div>
-          </div>
-        </>
-      ) : // 로그인 안된 상태 - 로그인/회원가입 화면
-      profilePanelMode === 'signup' ? (
-        <SignUpPanel />
-      ) : (
-        <div className="text-center p-4">
-          <div className="flex flex-col items-center mb-[24px]">
-            <Iconframe color="primary" size="medium" className="mb-[16px]">
-              <FiUser />
-            </Iconframe>
-            <h3 className="text-white font-semibold text-base">WELCOME BACK</h3>
-            <p className="text-text-muted text-sm">
-              SIGN IN TO CREATE AND
-              <br />
-              MANAGE SYSTEMS
-            </p>
-          </div>
-          <div className="flex flex-col mt-[24px] text-left gap-[16px]">
-            <TextField label="Email" htmlFor="email">
-              <TextInput
-                type="email"
-                placeholder="Enter your email"
-                id="email"
-              />
-            </TextField>
-            <TextField label="Password" htmlFor="password">
-              <TextInput
-                type="password"
-                placeholder="Enter your password"
-                id="password"
-              />
-            </TextField>
-          </div>
-          <Button color="primary" size="lg" className="w-full mt-[24px]">
-            SIGN IN
-          </Button>
-          <div className="flex justify-center mt-[24px] mb-[24px]">
-            <a
-              href="#"
-              className="text-primary-300 text-xs hover:text-primary-200 transition-colors cursor-pointer"
-            >
-              FORGOT PASSWORD?
-            </a>
-          </div>
-          <div className="flex flex-col items-center border-t border-gray-border pt-[24px]">
-            <p className="text-text-muted text-xs mb-[8px]">
-              DON'T HAVE AN ACCOUNT?
-            </p>
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setProfilePanelMode('signup');
-              }}
-              className="text-primary-300 text-sm font-semibold hover:text-primary-200 transition-colors cursor-pointer"
-            >
-              SIGN UP
-            </a>
-          </div>
-        </div>
-      )}
+    <div className="h-full flex flex-col overflow-hidden">
+      {renderContent()}
     </div>
   );
 }

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/ProfileView.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/ProfileView.tsx
@@ -1,0 +1,124 @@
+import {
+  FiEdit3,
+  FiUser,
+  FiLogOut,
+  FiChevronRight,
+  FiHeart,
+  FiUserCheck,
+} from 'react-icons/fi';
+import { IoPlanetOutline } from 'react-icons/io5';
+import { useSidebarStore } from '@/stores/sidebarStore';
+import Iconframe from '@/components/common/Iconframe';
+import Button from '@/components/common/Button';
+import Card from '@/components/common/Card';
+
+export default function ProfileView() {
+  const { setProfilePanelMode } = useSidebarStore();
+
+  // 임시 데이터
+  const profile = {
+    username: '테스터',
+    email: 'tester@example.com',
+    joinDate: '2024-01-01',
+    about: 'aboutaboutabout',
+  };
+
+  const handleLikesClick = () => {
+    setProfilePanelMode('likes');
+  };
+
+  const handleFollowersClick = () => {
+    setProfilePanelMode('followers');
+  };
+
+  const handleFollowingsClick = () => {
+    setProfilePanelMode('followings');
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="flex flex-col items-center border-b border-gray-border p-6">
+        <div className="flex flex-col items-center mb-[24px]">
+          <Iconframe color="tertiary" size="large" className="mb-[16px]">
+            <FiUser />
+          </Iconframe>
+          <h3 className="text-white font-semibold text-base">
+            {profile.username}
+          </h3>
+          <p className="text-text-muted text-sm text-center">{profile.about}</p>
+        </div>
+        <Button color="secondary" size="lg" className="w-full">
+          <FiEdit3 />
+          EDIT PROFILE
+        </Button>
+      </div>
+      <div className="flex flex-col p-6 flex-1">
+        <p className="text-tertiary-200 text-sm font-semibold mb-[16px]">
+          STATISTICS
+        </p>
+        <div className="mb-[24px]">
+          <p className="text-text-muted text-sm mb-[16px]">STELLAR SYSTEMS</p>
+          <Card>
+            <div className="flex items-center justify-center gap-2 mb-[16px]">
+              <IoPlanetOutline className="text-tertiary-300 text-lg" />
+              <p className="text-text-muted text-sm">CREATED</p>
+            </div>
+            <p className="text-white text-center text-[24px] font-semibold">
+              3
+            </p>
+          </Card>
+        </div>
+        <div className="mb-[24px]">
+          <p className="text-text-muted text-sm mb-[16px]">LIKES</p>
+          <Card onClick={handleLikesClick} className="cursor-pointer">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center">
+                <FiHeart className="text-white text-lg mr-4" />
+                <div className="flex flex-col">
+                  <p className="text-white text-lg font-semibold">85</p>
+                  <p className="text-text-muted text-sm">MY LIKES</p>
+                </div>
+              </div>
+              <FiChevronRight className="text-text-muted text-lg" />
+            </div>
+          </Card>
+        </div>
+        <div className="mb-[24px]">
+          <p className="text-text-muted text-sm mb-[16px]">SOCIALS</p>
+          <div className="flex flex-col gap-[12px] w-full">
+            <Card onClick={handleFollowersClick} className="cursor-pointer">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center">
+                  <FiUser className="text-primary-300 text-lg mr-4" />
+                  <div className="flex flex-col">
+                    <p className="text-white text-lg font-semibold">24</p>
+                    <p className="text-text-muted text-sm">FOLLOWERS</p>
+                  </div>
+                </div>
+                <FiChevronRight className="text-text-muted text-lg" />
+              </div>
+            </Card>
+            <Card onClick={handleFollowingsClick} className="cursor-pointer">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center">
+                  <FiUserCheck className="text-secondary-300 text-lg mr-4" />
+                  <div className="flex flex-col">
+                    <p className="text-white text-lg font-semibold">18</p>
+                    <p className="text-text-muted text-sm">FOLLOWINGS</p>
+                  </div>
+                </div>
+                <FiChevronRight className="text-text-muted text-lg" />
+              </div>
+            </Card>
+          </div>
+        </div>
+      </div>
+      <div className="p-6 border-t border-gray-border">
+        <Button color="tertiary" size="lg" className="w-full">
+          <FiLogOut />
+          SIGN OUT
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/ProfileView.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/ProfileView.tsx
@@ -37,8 +37,8 @@ export default function ProfileView() {
   };
 
   return (
-    <div className="h-full overflow-hidden">
-      <ScrollArea className="h-full">
+    <div className="flex flex-col h-full overflow-hidden">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="flex flex-col">
           <div className="flex flex-col items-center border-b border-gray-border p-6">
             <div className="flex flex-col items-center mb-[24px]">
@@ -123,14 +123,14 @@ export default function ProfileView() {
               </div>
             </div>
           </div>
-          <div className="p-6 border-t border-gray-border">
-            <Button color="tertiary" size="lg" className="w-full">
-              <FiLogOut />
-              SIGN OUT
-            </Button>
-          </div>
         </div>
       </ScrollArea>
+      <div className="flex-shrink-0 p-6 border-t border-gray-border">
+        <Button color="tertiary" size="lg" className="w-full">
+          <FiLogOut />
+          SIGN OUT
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/Sidebar/SidebarPanel/Profile/ProfileView.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/ProfileView.tsx
@@ -11,6 +11,7 @@ import { useSidebarStore } from '@/stores/sidebarStore';
 import Iconframe from '@/components/common/Iconframe';
 import Button from '@/components/common/Button';
 import Card from '@/components/common/Card';
+import { ScrollArea } from '@/components/common/Scrollarea';
 
 export default function ProfileView() {
   const { setProfilePanelMode } = useSidebarStore();
@@ -36,89 +37,100 @@ export default function ProfileView() {
   };
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
-      <div className="flex flex-col items-center border-b border-gray-border p-6">
-        <div className="flex flex-col items-center mb-[24px]">
-          <Iconframe color="tertiary" size="large" className="mb-[16px]">
-            <FiUser />
-          </Iconframe>
-          <h3 className="text-white font-semibold text-base">
-            {profile.username}
-          </h3>
-          <p className="text-text-muted text-sm text-center">{profile.about}</p>
-        </div>
-        <Button color="secondary" size="lg" className="w-full">
-          <FiEdit3 />
-          EDIT PROFILE
-        </Button>
-      </div>
-      <div className="flex flex-col p-6 flex-1">
-        <p className="text-tertiary-200 text-sm font-semibold mb-[16px]">
-          STATISTICS
-        </p>
-        <div className="mb-[24px]">
-          <p className="text-text-muted text-sm mb-[16px]">STELLAR SYSTEMS</p>
-          <Card>
-            <div className="flex items-center justify-center gap-2 mb-[16px]">
-              <IoPlanetOutline className="text-tertiary-300 text-lg" />
-              <p className="text-text-muted text-sm">CREATED</p>
+    <div className="h-full overflow-hidden">
+      <ScrollArea className="h-full">
+        <div className="flex flex-col">
+          <div className="flex flex-col items-center border-b border-gray-border p-6">
+            <div className="flex flex-col items-center mb-[24px]">
+              <Iconframe color="tertiary" size="large" className="mb-[16px]">
+                <FiUser />
+              </Iconframe>
+              <h3 className="text-white font-semibold text-base">
+                {profile.username}
+              </h3>
+              <p className="text-text-muted text-sm text-center">
+                {profile.about}
+              </p>
             </div>
-            <p className="text-white text-center text-[24px] font-semibold">
-              3
+            <Button color="secondary" size="lg" className="w-full">
+              <FiEdit3 />
+              EDIT PROFILE
+            </Button>
+          </div>
+          <div className="flex flex-col p-6">
+            <p className="text-tertiary-200 text-sm font-semibold mb-[16px]">
+              STATISTICS
             </p>
-          </Card>
-        </div>
-        <div className="mb-[24px]">
-          <p className="text-text-muted text-sm mb-[16px]">LIKES</p>
-          <Card onClick={handleLikesClick} className="cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <FiHeart className="text-white text-lg mr-4" />
-                <div className="flex flex-col">
-                  <p className="text-white text-lg font-semibold">85</p>
-                  <p className="text-text-muted text-sm">MY LIKES</p>
+            <div className="mb-[24px]">
+              <p className="text-text-muted text-sm mb-[16px]">
+                STELLAR SYSTEMS
+              </p>
+              <Card>
+                <div className="flex items-center justify-center gap-2 mb-[16px]">
+                  <IoPlanetOutline className="text-tertiary-300 text-lg" />
+                  <p className="text-text-muted text-sm">CREATED</p>
                 </div>
-              </div>
-              <FiChevronRight className="text-text-muted text-lg" />
+                <p className="text-white text-center text-[24px] font-semibold">
+                  3
+                </p>
+              </Card>
             </div>
-          </Card>
-        </div>
-        <div className="mb-[24px]">
-          <p className="text-text-muted text-sm mb-[16px]">SOCIALS</p>
-          <div className="flex flex-col gap-[12px] w-full">
-            <Card onClick={handleFollowersClick} className="cursor-pointer">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center">
-                  <FiUser className="text-primary-300 text-lg mr-4" />
-                  <div className="flex flex-col">
-                    <p className="text-white text-lg font-semibold">24</p>
-                    <p className="text-text-muted text-sm">FOLLOWERS</p>
+            <div className="mb-[24px]">
+              <p className="text-text-muted text-sm mb-[16px]">LIKES</p>
+              <Card onClick={handleLikesClick} className="cursor-pointer">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center">
+                    <FiHeart className="text-white text-lg mr-4" />
+                    <div className="flex flex-col">
+                      <p className="text-white text-lg font-semibold">85</p>
+                      <p className="text-text-muted text-sm">MY LIKES</p>
+                    </div>
                   </div>
+                  <FiChevronRight className="text-text-muted text-lg" />
                 </div>
-                <FiChevronRight className="text-text-muted text-lg" />
-              </div>
-            </Card>
-            <Card onClick={handleFollowingsClick} className="cursor-pointer">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center">
-                  <FiUserCheck className="text-secondary-300 text-lg mr-4" />
-                  <div className="flex flex-col">
-                    <p className="text-white text-lg font-semibold">18</p>
-                    <p className="text-text-muted text-sm">FOLLOWINGS</p>
+              </Card>
+            </div>
+            <div className="mb-[24px]">
+              <p className="text-text-muted text-sm mb-[16px]">SOCIALS</p>
+              <div className="flex flex-col gap-[12px] w-full">
+                <Card onClick={handleFollowersClick} className="cursor-pointer">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                      <FiUser className="text-primary-300 text-lg mr-4" />
+                      <div className="flex flex-col">
+                        <p className="text-white text-lg font-semibold">24</p>
+                        <p className="text-text-muted text-sm">FOLLOWERS</p>
+                      </div>
+                    </div>
+                    <FiChevronRight className="text-text-muted text-lg" />
                   </div>
-                </div>
-                <FiChevronRight className="text-text-muted text-lg" />
+                </Card>
+                <Card
+                  onClick={handleFollowingsClick}
+                  className="cursor-pointer"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                      <FiUserCheck className="text-secondary-300 text-lg mr-4" />
+                      <div className="flex flex-col">
+                        <p className="text-white text-lg font-semibold">18</p>
+                        <p className="text-text-muted text-sm">FOLLOWINGS</p>
+                      </div>
+                    </div>
+                    <FiChevronRight className="text-text-muted text-lg" />
+                  </div>
+                </Card>
               </div>
-            </Card>
+            </div>
+          </div>
+          <div className="p-6 border-t border-gray-border">
+            <Button color="tertiary" size="lg" className="w-full">
+              <FiLogOut />
+              SIGN OUT
+            </Button>
           </div>
         </div>
-      </div>
-      <div className="p-6 border-t border-gray-border">
-        <Button color="tertiary" size="lg" className="w-full">
-          <FiLogOut />
-          SIGN OUT
-        </Button>
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/src/stores/sidebarStore.ts
+++ b/src/stores/sidebarStore.ts
@@ -4,19 +4,27 @@ interface SidebarState {
   isSecondaryOpen: boolean;
   selectedMenu: string | null;
   isLoggedIn: boolean;
-  profilePanelMode: 'login' | 'signup';
+  profilePanelMode:
+    | 'login'
+    | 'signup'
+    | 'profile'
+    | 'likes'
+    | 'followers'
+    | 'followings';
   openSecondarySidebar: (menu: string) => void;
   closeSecondarySidebar: () => void;
   toggleSecondarySidebar: (menu: string) => void;
   setLoginStatus: (status: boolean) => void;
-  setProfilePanelMode: (mode: 'login' | 'signup') => void;
+  setProfilePanelMode: (
+    mode: 'login' | 'signup' | 'profile' | 'likes' | 'followers' | 'followings'
+  ) => void;
 }
 
 export const useSidebarStore = create<SidebarState>((set, get) => ({
   isSecondaryOpen: false,
   selectedMenu: null,
   isLoggedIn: true, // 기본값: 로그인됨 (테스트용)
-  profilePanelMode: 'login', // 기본값: 로그인 모드
+  profilePanelMode: 'profile', // 기본값: 프로필 모드
   openSecondarySidebar: (menu: string) =>
     set({
       isSecondaryOpen: true,
@@ -48,7 +56,9 @@ export const useSidebarStore = create<SidebarState>((set, get) => ({
     set({
       isLoggedIn: status,
     }),
-  setProfilePanelMode: (mode: 'login' | 'signup') =>
+  setProfilePanelMode: (
+    mode: 'login' | 'signup' | 'profile' | 'likes' | 'followers' | 'followings'
+  ) =>
     set({
       profilePanelMode: mode,
     }),


### PR DESCRIPTION
## 작업 내용
- 프로필 패널 관련 컴포넌트를 분리
- 라우팅으로 각 패널을 관리하도록 구현
- 좋아요 패널 레이아웃 구현 (galaxy 패널 CardItem.tsx 재사용)
- 프로필 뷰 패널, 좋아요 패널에 스크롤바 추가

## TODO
- CardItem.tsx 컴포넌트 개선 (galaxyName이 길어지자 카드 길이가 길어짐)
- 프로필 뷰 패널, 좋아요 패널 외에도 스크롤바 추가
- galaxy & stella(system) 패널의 파일 위치 수정