### PR TITLE
[리팩토링] Card 컴포넌트 import 경로수정 및 갤럭시 리스트 클릭 시 Stellar 패널로 전환되면서 INFO 탭으로 전환되게 변경

### DIFF
--- a/src/components/panel/galaxy/community/List.tsx
+++ b/src/components/panel/galaxy/community/List.tsx
@@ -11,6 +11,7 @@ import { SkeletonCard } from '@/components/common/Card/SkeletonCard';
 import { ErrorBoundary } from 'react-error-boundary';
 import LoadingIcon from '@/components/common/LoadingIcon';
 import { useSelectedStellarStore } from '@/stores/useSelectedStellarStore';
+import { useStellarTabStore } from '@/stores/useStellarTabStore';
 
 const GALAXY_LIST_LIMIT = 3;
 
@@ -27,6 +28,7 @@ export default function List({ sort }: { sort: SortLabel }) {
 // 갤럭시 리스트 컨텐츠
 function ContentComp({ sort }: { sort: SortLabel }) {
   const { setSelectedStellarId } = useSelectedStellarStore();
+  const { setTabValue } = useStellarTabStore();
 
   // 갤럭시 리스트 데이터
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -49,6 +51,7 @@ function ContentComp({ sort }: { sort: SortLabel }) {
             onClick={() => {
               // 갤럭시 id 값 변경 => 스텔라 정보 api 호출 및 갱신 후 => 스토어에 저장
               setSelectedStellarId(galaxySystem.id);
+              setTabValue('INFO');
             }}
           />
         ))}

--- a/src/components/panel/stellar/properties/Properties.tsx
+++ b/src/components/panel/stellar/properties/Properties.tsx
@@ -3,7 +3,7 @@ import ControlPanel from './Gauges';
 import Random from './Random';
 import { useStellarStore } from '@/stores/useStellarStore';
 import { useSelectedObjectStore } from '@/stores/useSelectedObjectStore';
-import Card from '@/components/common/Card';
+import Card from '@/components/common/Card/Card';
 import Button from '@/components/common/Button';
 import { useEffect, useMemo, useState } from 'react';
 import type { Planet, SoundType } from '@/types/stellar';


### PR DESCRIPTION
## 작업 내용
- Card 컴포넌트 import 경로 수정
- 갤럭시 리스트 클릭 시 Stellar 패널로 전환되면서 INFO 탭으로 전환되게 변경