### PR TITLE
[수정] 스텔라 패널 에서 OBJECTS, PROPERTIES 탭 비활성화 기준 수정

### DIFF
--- a/src/components/panel/stellar/StellarIndex.tsx
+++ b/src/components/panel/stellar/StellarIndex.tsx
@@ -23,6 +23,9 @@ export default function StellarIndex() {
   const { stellarStore } = useStellarStore();
   const { userStore } = useUserStore();
   const isStellarOwner = stellarStore.userId === userStore.userId;
+  console.log('stellarStore.userId : ', stellarStore.userId);
+  console.log('userStore.userId : ', userStore.userId);
+  console.log('isStellarOwner : ', isStellarOwner);
 
   // Stellar 패널 Tab value 스토어
   const { tabValue, setTabValue } = useStellarTabStore();
@@ -42,10 +45,16 @@ export default function StellarIndex() {
         >
           <TabsList className="grid w-full [grid-template-columns:repeat(3,minmax(max-content,1fr))] gap-0 shrink-0">
             <TabsTrigger value="INFO">INFO</TabsTrigger>
-            <TabsTrigger value="OBJECTS" disabled={!isStellarOwner}>
+            <TabsTrigger
+              value="OBJECTS"
+              disabled={!isStellarOwner && mode === 'view'}
+            >
               OBJECTS
             </TabsTrigger>
-            <TabsTrigger value="PROPERTIES" disabled={!isStellarOwner}>
+            <TabsTrigger
+              value="PROPERTIES"
+              disabled={!isStellarOwner && mode === 'view'}
+            >
               PROPERTIES
             </TabsTrigger>
           </TabsList>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -5,7 +5,7 @@ import galaxiesMy from './data/galaxiesMy';
 import { stellar } from './data/stellar';
 import { mockFetch, mockFetchInfinite } from './utils';
 
-const isLoggedIn = false; // 로그인 여부 테스트용
+const isLoggedIn = true; // 로그인 여부 테스트용
 
 export const handlers = [
   // 세션 확인

--- a/src/stores/useStellarStore.ts
+++ b/src/stores/useStellarStore.ts
@@ -51,7 +51,7 @@ const dummyStellarStore: StellarType = {
 const initialStellarStore: StellarType = {
   userId: '',
   stellarId: '', // 백엔드 자동 생성
-  stellarName: 'CENTRAL STAR SYSTEM', // 백엔드 자동 생성성
+  stellarName: 'CENTRAL STAR SYSTEM', // 백엔드 자동 생성
   updatedAt: '', // 현재 시각 (초기값만 프론트에서 제공)
   objects: [
     {

--- a/src/utils/valueToColor.ts
+++ b/src/utils/valueToColor.ts
@@ -1,5 +1,8 @@
 // min ~ max 범위의 값 → HSL 색상 반환
 export function valueToColor(value: number, min: number, max: number) {
+  if (max === min) {
+    return `hsl(0, 100%, 50%)`; // 기본 색상(예: 빨강) 반환
+  }
   const ratio = (value - min) / (max - min); // 0~1 정규화
   const hue = ratio * 360; // 0~360 Hue 매핑
   return `hsl(${hue}, 100%, 50%)`; // 채도 100%, 밝기 50%


### PR DESCRIPTION
## 작업 내용
- 기존엔 스텔라 정보의 userId랑 user스토어의 userId랑 다르면 비활성화였는데, 수정 후 => view 모드일 경우도 추가함