### PR TITLE
[리팩토링] 스텔라 리스트, 상세 정보 타입 및 스토어 확장 및 날짜 포맷 변경

### DIFF
--- a/src/components/common/ButtonFavorite.tsx
+++ b/src/components/common/ButtonFavorite.tsx
@@ -1,5 +1,8 @@
 import Button from '@/components/common/Button';
 import { FaHeart, FaRegHeart } from 'react-icons/fa';
+import { mergeClassNames } from '@/utils/mergeClassNames';
+import { FaHeartCirclePlus } from 'react-icons/fa6';
+import { FaHeartCrack } from 'react-icons/fa6';
 
 interface ButtonFavoriteProps {
   className?: string;
@@ -24,10 +27,27 @@ export default function ButtonFavorite({
   return (
     <Button
       color="transparent"
-      className={`w-[30px] h-[40px] ${className}`}
+      className={mergeClassNames(
+        'group relative grid place-items-center w-[30px] h-[40px] hover:cursor-pointer',
+        className
+      )}
       onClick={onClickHandle}
     >
-      {active ? <FaHeart /> : <FaRegHeart />}
+      {/* 기본 아이콘: 상태별로 다름 */}
+      {active ? (
+        <FaHeart className="w-5 h-5 transition-opacity duration-150 opacity-100 group-hover:opacity-0" />
+      ) : (
+        <FaRegHeart className="w-5 h-5 transition-opacity duration-150 opacity-100 group-hover:opacity-0" />
+      )}
+
+      {/* 호버 아이콘: 상태별로 다름 (오버레이) */}
+      <span className="pointer-events-none absolute inset-0 grid place-items-center">
+        {active ? (
+          <FaHeartCrack className="w-5 h-5 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
+        ) : (
+          <FaHeartCirclePlus className="w-5 h-5 opacity-0 transition-opacity duration-150 group-hover:opacity-100" />
+        )}
+      </span>
     </Button>
   );
 }

--- a/src/components/panel/galaxy/community/CardItem.tsx
+++ b/src/components/panel/galaxy/community/CardItem.tsx
@@ -6,6 +6,7 @@ import type { StellarListItem } from '@/types/stellarList';
 import { useState } from 'react';
 import { useCreateLike, useDeleteLike } from '@/hooks/api/useLikes';
 import { useUserStore } from '@/stores/useUserStore';
+import { formatDateToYMD } from '@/utils/formatDateToYMD';
 
 interface CardItemProps extends StellarListItem {
   onClick: () => void;
@@ -15,15 +16,16 @@ export default function CardItem({
   id,
   rank,
   title,
-  creator_id,
+  // creator_id,
+  creator_name,
   updated_at,
   planet_count,
   like_count,
   is_liked,
   onClick,
 }: CardItemProps) {
+  console.log('creator_name', creator_name);
   const { isLoggedIn } = useUserStore();
-  console.log('isLoggedIn', isLoggedIn);
   const [favoriteActive, setFavoriteActive] = useState(is_liked);
   // 좋아요 hook
   const { mutate: createLike } = useCreateLike();
@@ -57,7 +59,7 @@ export default function CardItem({
   };
 
   return (
-    <Card onClick={onClick} role="button">
+    <Card onClick={onClick} role="button" className="hover:cursor-pointer">
       <div className="flex items-center justify-between min-w-0 w-full max-w-full">
         {/* ← 왼쪽 영역: 줄어들 수 있게 basis-0 grow min-w-0 */}
         <div className="basis-0 grow min-w-0">
@@ -76,12 +78,12 @@ export default function CardItem({
               className="min-w-0 w-full"
             >
               <span>BY</span>
-              <span className="truncate text-primary-300">{creator_id}</span>
+              <span className="truncate text-primary-300">{creator_name}</span>
             </div>
 
             {/* 날짜 */}
             <div className="grid grid-cols-[auto,1fr] gap-1 min-w-0 w-full">
-              <span className="truncate">{updated_at}</span>
+              <span className="truncate">{formatDateToYMD(updated_at)}</span>
             </div>
           </div>
         </div>

--- a/src/components/panel/galaxy/my/CardItem.tsx
+++ b/src/components/panel/galaxy/my/CardItem.tsx
@@ -2,6 +2,7 @@ import Card from '@/components/common/Card/Card';
 import { IoPlanetOutline } from 'react-icons/io5';
 import { FaRegHeart } from 'react-icons/fa';
 import type { StellarListItem } from '@/types/stellarList';
+import { formatDateToYMD } from '@/utils/formatDateToYMD';
 
 interface CardItemProps extends StellarListItem {
   onClick: () => void;
@@ -15,14 +16,14 @@ export default function CardItem({
   onClick,
 }: CardItemProps) {
   return (
-    <Card onClick={onClick} role="button">
+    <Card onClick={onClick} role="button" className="hover:cursor-pointer">
       <div className="flex items-center justify-between min-w-0">
         <div className="flex-1 min-w-0">
           <div className="flex items-center text-[14px] font-bold min-w-0">
             <strong className="text-white w-0 flex-1 truncate">{title}</strong>
           </div>
           <div className="mt-3 flex flex-col items-start gap-1 text-[12px] text-text-muted">
-            <span>{updated_at}</span>
+            <span>{formatDateToYMD(updated_at)}</span>
           </div>
         </div>
       </div>

--- a/src/components/panel/stellar/info/CloneStellarButton.tsx
+++ b/src/components/panel/stellar/info/CloneStellarButton.tsx
@@ -1,10 +1,10 @@
 import Button from '@/components/common/Button';
 import { useCloneStellar } from '@/hooks/api/useStellar';
 import { useSidebarStore } from '@/stores/useSidebarStore';
-import { useSelectedObjectStore } from '@/stores/useSelectedObjectStore';
+import { useSelectedStellarStore } from '@/stores/useSelectedStellarStore';
 
 export default function CloneStellarButton() {
-  const { selectedObjectId } = useSelectedObjectStore();
+  const { selectedStellarId } = useSelectedStellarStore();
   const { mutate: cloneStellar, isPending } = useCloneStellar();
   const { openSecondarySidebar } = useSidebarStore();
 
@@ -18,7 +18,7 @@ export default function CloneStellarButton() {
       className="w-full mt-6"
       disabled={isPending}
       onClick={() => {
-        cloneStellar(selectedObjectId, {
+        cloneStellar(selectedStellarId, {
           onSuccess: () => {
             openSecondarySidebar('galaxy');
           },

--- a/src/components/panel/stellar/info/DeleteStellarButton.tsx
+++ b/src/components/panel/stellar/info/DeleteStellarButton.tsx
@@ -17,7 +17,7 @@ export default function DeleteStellarButton() {
   return (
     <Button
       color="transparent"
-      className="w-full text-text-muted mt-3 text-xs"
+      className="w-full text-text-muted mt-3 text-xs hover:text-error/80"
       disabled={isPending}
       onClick={() => {
         const confirm = window.confirm('DEACTIVATE ACCOUNT');
@@ -38,7 +38,7 @@ export default function DeleteStellarButton() {
         }
       }}
     >
-      DEACTIVATE ACCOUNT
+      DEACTIVATE STELLAR
     </Button>
   );
 }

--- a/src/components/panel/stellar/info/StellarInfo.tsx
+++ b/src/components/panel/stellar/info/StellarInfo.tsx
@@ -7,6 +7,7 @@ import { useStellarStore } from '@/stores/useStellarStore';
 import CloneStellarButton from './CloneStellarButton';
 import DeleteStellarButton from './DeleteStellarButton';
 import { useUserStore } from '@/stores/useUserStore';
+import { formatDateToYMD } from '@/utils/formatDateToYMD';
 
 export default function StellarInfo({
   isStellarOwner,
@@ -29,9 +30,10 @@ export default function StellarInfo({
 
   // 3) 스타 정보 (표시용)
   const starInfo = {
-    NAME: stellarStore.title,
-    CREATOR: stellarStore.author_id,
-    AUTHOR: stellarStore.create_source_id,
+    STELLAR_TITLE: stellarStore.title,
+    STAR_NAME: stellarStore.star.name,
+    CREATOR: stellarStore.creator_name,
+    AUTHOR: stellarStore.author_name,
     ['CREATE SOURCE']: 'ORIGINAL COMPOSITION',
     ['ORIGINAL SOURCE']: 'SONA STUDIO',
   };
@@ -46,7 +48,7 @@ export default function StellarInfo({
     <div>
       {/* 타이틀 */}
       <PanelTitle fontSize="large" textColor="text-primary-300">
-        행성 INFO
+        {isStarSelected ? 'STAR INFO' : 'PLANET INFO'}
       </PanelTitle>
 
       {/* INFO 카드 */}
@@ -61,34 +63,90 @@ export default function StellarInfo({
             case 'object_type':
               return null;
 
-            case 'name':
+            case 'stellar_title':
               return (
                 <div key={rawKey}>
-                  <PanelTitle className="font-normal mb-1">NAME</PanelTitle>
+                  <PanelTitle className="font-normal mb-1">
+                    STELLAR TITLE
+                  </PanelTitle>
                   {isStellarOwner || mode === 'create' ? (
+                    // 스텔라 Title
                     <TextInput
                       className="text-sm"
                       value={String(value)}
                       onChange={(e) => {
-                        const nextName = e.target.value;
-
-                        if (isStarSelected || !planetInfo) {
-                          setStellarStore({ ...stellarStore, title: nextName });
-                        } else {
-                          setStellarStore({
-                            ...stellarStore,
-                            planets: stellarStore.planets.map((planet) =>
-                              planet.id === selectedObjectId
-                                ? { ...planet, name: nextName }
-                                : planet
-                            ),
-                          });
-                        }
+                        const nextTitle = e.target.value;
+                        setStellarStore({
+                          ...stellarStore,
+                          title: nextTitle,
+                        });
                       }}
                     />
                   ) : (
                     <p className="text-text-secondary">{String(value)}</p>
                   )}
+                </div>
+              );
+            case 'star_name':
+              return (
+                <div key={rawKey}>
+                  <PanelTitle className="font-normal mb-1">
+                    STAR NAME
+                  </PanelTitle>
+                  {isStellarOwner || mode === 'create' ? (
+                    // STAR Name
+                    <TextInput
+                      className="text-sm"
+                      value={String(value)}
+                      onChange={(e) => {
+                        const nextName = e.target.value;
+                        setStellarStore({
+                          ...stellarStore,
+                          star: { ...stellarStore.star, name: nextName },
+                        });
+                      }}
+                    />
+                  ) : (
+                    <p className="text-text-secondary">{String(value)}</p>
+                  )}
+                </div>
+              );
+            case 'name':
+              return (
+                <div key={rawKey}>
+                  <PanelTitle className="font-normal mb-1">NAME</PanelTitle>
+                  {isStellarOwner || mode === 'create' ? (
+                    // PLANET Name
+                    <TextInput
+                      className="text-sm"
+                      value={String(value)}
+                      onChange={(e) => {
+                        const nextName = e.target.value;
+                        setStellarStore({
+                          ...stellarStore,
+                          planets: stellarStore.planets.map((planet) =>
+                            planet.id === selectedObjectId
+                              ? { ...planet, name: nextName }
+                              : planet
+                          ),
+                        });
+                      }}
+                    />
+                  ) : (
+                    <p className="text-text-secondary">{String(value)}</p>
+                  )}
+                </div>
+              );
+            case 'updated_at':
+            case 'created_at':
+              return (
+                <div key={rawKey}>
+                  <PanelTitle className="font-normal mb-1">
+                    {rawKey.toUpperCase().replace('_', ' ')}
+                  </PanelTitle>
+                  <p className="text-text-secondary">
+                    {formatDateToYMD(String(value))}
+                  </p>
                 </div>
               );
 

--- a/src/components/panel/stellar/objects/Objects.tsx
+++ b/src/components/panel/stellar/objects/Objects.tsx
@@ -43,9 +43,9 @@ function ObjectsContent() {
       <div className="space-y-3">
         {objectsInfo.length > 0 ? (
           objectsInfo.map((data) => {
-            const title =
+            const name =
               data.object_type === 'STAR'
-                ? stellarStore.title
+                ? stellarStore.star.name
                 : (data.name ?? 'UNTITLED');
 
             return (
@@ -58,7 +58,7 @@ function ObjectsContent() {
                 }}
                 active={selectedObjectId === data.id}
                 className="cursor-pointer"
-                title={title}
+                name={name}
               />
             );
           })

--- a/src/components/panel/stellar/objects/StellarCard.tsx
+++ b/src/components/panel/stellar/objects/StellarCard.tsx
@@ -2,13 +2,14 @@ import Card from '@/components/common/Card/Card';
 import type { Star, Planet } from '@/types/stellar';
 import { mergeClassNames } from '@/utils/mergeClassNames';
 import { valueToColor } from '@/utils/valueToColor';
+import { FaStar } from 'react-icons/fa';
 
 interface StellarCardProps {
   data: Star | Planet;
   onClick: () => void;
   active: boolean;
   className?: string;
-  title: string;
+  name: string;
 }
 
 export default function StellarCard({
@@ -16,7 +17,7 @@ export default function StellarCard({
   onClick,
   active,
   className,
-  title,
+  name,
 }: StellarCardProps) {
   const description =
     data.object_type === 'PLANET' ? 'PLANET • ' + data.role : 'CENTRAL STAR';
@@ -31,9 +32,9 @@ export default function StellarCard({
       )}
     >
       <div className="flex gap-3 items-center">
+        {/* 색상 동그라미 */}
         <div
-          className={`w-[24px] h-[24px] rounded-full border-[2px] border-[rgba(255,255,255,0.2)]`}
-          // style={{ backgroundColor: getPlanetColor(index) }}
+          className={`w-[24px] h-[24px] rounded-full border-[2px] border-[rgba(255,255,255,0.2)] shrink-0`}
           style={{
             backgroundColor: valueToColor(
               data.object_type === 'PLANET'
@@ -44,10 +45,27 @@ export default function StellarCard({
             ),
           }}
         ></div>
-        <div>
-          <strong className="text-text-white">{title}</strong>
+        {/* 이름과 설명 */}
+        <div className="flex-1">
+          <strong
+            className="block text-text-white"
+            style={{
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {name}
+          </strong>
           <p className="text-text-muted">{description}</p>
         </div>
+        {/* 별자리 아이콘 : STAR 경우만 */}
+        {data.object_type === 'STAR' && (
+          <div className="w-[24px] h-[24px] shrink-0 text-[#FACC15]">
+            <FaStar />
+          </div>
+        )}
       </div>
     </Card>
   );

--- a/src/stores/useStellarStore.ts
+++ b/src/stores/useStellarStore.ts
@@ -10,6 +10,7 @@ import type { StarProperties } from '@/types/starProperties';
 import type { PlanetProperties } from '@/types/planetProperties';
 import { useUserStore } from '@/stores/useUserStore';
 import { createDefaultProperties } from '@/types/planetProperties';
+import { formatDateToYMD } from '@/utils/formatDateToYMD';
 
 /***** 1) 기본 프로퍼티 디폴트 *****/
 const defaultStarProps: StarProperties = {
@@ -33,6 +34,10 @@ export const initialStellarStore: StellarSystem = {
   created_via: 'MANUAL',
   created_at: '',
   updated_at: '',
+  author_name: '',
+  creator_name: '',
+  create_source_name: '',
+  original_source_name: '',
 
   star: {
     id: 'star_001',
@@ -47,12 +52,7 @@ export const initialStellarStore: StellarSystem = {
   position: [0, 0, 0],
 };
 
-/***** 3) 유틸: 임시 ID 생성 *****/
-// function genId(prefix: string = 'tmp'): string {
-//   return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-// }
-
-/***** 4) 스토어 타입 *****/
+/***** 3) 스토어 타입 *****/
 interface StellarStore {
   stellarStore: StellarSystem;
   setStellarStore: (stellarStore: StellarSystem) => void;
@@ -64,14 +64,26 @@ interface StellarStore {
 export const useStellarStore = create<StellarStore>((set) => ({
   stellarStore: initialStellarStore,
 
-  setStellarStore: (stellarStore) => set({ stellarStore }),
+  setStellarStore: (stellarStore) =>
+    set(() => {
+      console.log('stellarStore', stellarStore);
+      return {
+        stellarStore: {
+          ...stellarStore,
+          updated_at: formatDateToYMD(),
+        },
+      };
+    }),
 
   setInitialStellarStore: () =>
     set(() => {
       // 작성자/소유자 계열 필드를 userId 기반으로 세팅 => 비로그인 경우 '' 빈 값
       // 훅 호출하지 않고, 스토어 인스턴스의 getState() 사용
       const userId = useUserStore.getState().userStore.id ?? '';
-      const now = new Date().toISOString();
+      const now = formatDateToYMD();
+      const userName = useUserStore.getState().userStore.username ?? '';
+      console.log('userName', userName);
+
       return {
         stellarStore: {
           ...initialStellarStore,
@@ -81,6 +93,11 @@ export const useStellarStore = create<StellarStore>((set) => ({
           original_source_id: userId,
           created_at: now,
           updated_at: now,
+          author_name: userName,
+          creator_name: userName,
+          create_source_name: userName,
+          original_source_name: userName,
+
           star: {
             ...(initialStellarStore.star as Star),
             system_id: '',
@@ -106,7 +123,7 @@ export const useStellarStore = create<StellarStore>((set) => ({
         role: 'DRUM' as InstrumentRole,
         properties: { ...defaultPlanetProps },
         created_at: '',
-        updated_at: new Date().toISOString(),
+        updated_at: formatDateToYMD(),
       };
 
       const nextPlanets = [...prev.planets, newPlanet];
@@ -116,7 +133,7 @@ export const useStellarStore = create<StellarStore>((set) => ({
         stellarStore: {
           ...prev,
           planets: nextPlanets,
-          updated_at: new Date().toISOString(),
+          updated_at: formatDateToYMD(),
         },
       };
     });

--- a/src/types/stellar.ts
+++ b/src/types/stellar.ts
@@ -24,6 +24,12 @@ export interface StellarSystem {
   title: string; // 스텔라(항성계) 이름
   galaxy_id: string; // 소속 갤럭시 ID 추가
 
+  // 추가된 name 필드
+  author_name: string; // 최초 생성자
+  creator_name: string; // 현재 소유자
+  create_source_name: string; // 클론한 스텔라
+  original_source_name: string; // 최초 스텔라
+
   // 원작자 추적 정보 (새로운 필드명 사용)
   creator_id: string; // 현재 소유자
   author_id: string; // 최초 생성자 (원작자)

--- a/src/types/stellarList.ts
+++ b/src/types/stellarList.ts
@@ -4,8 +4,8 @@ export interface StellarListItem {
   id: string;
   title: string;
   galaxy_id: string;
-  creator_id: string;
-  author_id: string;
+  // creator_id: string;
+  creator_name: string;
   created_at: string;
   updated_at: string;
   like_count: number;

--- a/src/utils/formatDateToYMD.ts
+++ b/src/utils/formatDateToYMD.ts
@@ -1,0 +1,7 @@
+export function formatDateToYMD(input: Date | string = new Date()): string {
+  const date = typeof input === 'string' ? new Date(input) : input;
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}


### PR DESCRIPTION
## 작업 내용
- 스텔라/스타/플래닛 명명 규칙 분리
- STELLAR TITLE(스텔라 제목), STAR NAME(항성 이름), PLANET NAME(행성 이름)로 구분
- 타입 및 스토어 확장
- author_name, creator_name 필드 추가 및 관련 로직 반영
- 날짜 포맷 유틸 도입
- 원본 문자열(예: 2025-09-17T13:17:21.682Z)을 formatDateToYMD로 변환해 표시
- updated_at, created_at 렌더링 로직에 적용
- UI 컴포넌트 개선
- 필드 분리에 맞춰 입력/표시 컴포넌트 갱신
- 즐겨찾기 버튼 호버 상태에서 아이콘 전환 및 효과 개선

## 참고 사항
- 기존에 title/name를 혼용하던 컴포넌트들은 새 필드에 맞게 키 매핑이 필요한지 확인 필요
- 날짜 표시는 로컬 시간 기준 YYYY-MM-DD로 통일됨
- 백엔드가 UTC 문자열을 주는 경우, 의도한 타임존과 불일치가 없는지 점검
- formatDateToYMD는 Date | string 모두 입력 가능하도록 구현되어야 함
- 스토어/타입 변경으로 인한 API 연동부(요청/응답 타입)와 테스트 코드 업데이트 필요