### PR TITLE
[리팩토링] 저장/삭제 작업에 확인 다이얼로그 추가

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -14,7 +14,7 @@ interface HeaderProps {
 
 export default function Header({ className, children }: HeaderProps) {
   const { isLoggedIn } = useUserStore();
-  const { setIdle } = useSelectedStellarStore();
+  const { mode, setIdle } = useSelectedStellarStore();
   return (
     <header
       className={mergeClassNames(
@@ -37,26 +37,19 @@ export default function Header({ className, children }: HeaderProps) {
       <nav className="flex-1 flex items-center justify-center">{children}</nav>
 
       {/* 우측 사용자 메뉴 영역 - 로그인 상태일 때만 표시 */}
-      {isLoggedIn && (
-        <div className="flex items-center gap-3">
-          {/* 항성계 정보 텍스트 => 기획에서 제거됨 */}
-          {/* <div className="text-right mr-2">
-            <div className="text-white text-[14px] font-medium leading-tight">
-              항성계 이름
-            </div>
-            <div className="text-text-muted text-[12px] leading-tight">
-              by {userStore.username || '제작자명'}
-            </div>
-          </div> */}
+      {isLoggedIn && <SaveButton />}
 
-          <SaveButton />
-
-          {/* BACK TO GALAXY 버튼 */}
-          <Button color="tertiary" size="sm" onClick={() => setIdle()}>
-            <FiArrowLeft className="w-4 h-4" />
-            BACK TO GALAXY
-          </Button>
-        </div>
+      {/* BACK TO GALAXY 버튼 */}
+      {mode !== 'idle' && (
+        <Button
+          className="ml-2"
+          color="tertiary"
+          size="sm"
+          onClick={() => setIdle()}
+        >
+          <FiArrowLeft className="w-4 h-4" />
+          BACK TO GALAXY
+        </Button>
       )}
     </header>
   );

--- a/src/components/layout/Header/SaveButton.tsx
+++ b/src/components/layout/Header/SaveButton.tsx
@@ -5,14 +5,17 @@ import { useSelectedStellarStore } from '@/stores/useSelectedStellarStore';
 import { useStellarStore } from '@/stores/useStellarStore';
 import { useUserStore } from '@/stores/useUserStore';
 import { useSidebarStore } from '@/stores/useSidebarStore';
+import { useState } from 'react';
 
 export default function SaveButton() {
+  const [saveConfirm, setSaveConfirm] = useState(false);
+
   const { mutate: createStellar, isPending: isCreatePending } =
     useCreateStellar();
   const { mutate: updateStellar, isPending: isUpdatePending } =
     useUpdateStellar();
-  const { mode, setIdle } = useSelectedStellarStore();
-  const { stellarStore, setInitialStellarStore } = useStellarStore();
+  const { mode } = useSelectedStellarStore();
+  const { stellarStore } = useStellarStore();
   const { userStore, isLoggedIn } = useUserStore();
   const { openSecondarySidebar } = useSidebarStore();
 
@@ -28,13 +31,9 @@ export default function SaveButton() {
     // 1. (생성) create 모드
     // 완료 시 => selectedStellarStore 초기화 & stellarStore 초기화 & 갤럭시 패널 이동
     if (mode === 'create') {
-      console.log('create모드 => save버튼 클릭 => 생성');
       createStellar(stellarStore, {
         onSuccess: () => {
-          // 그대로 두는 방식으로 변경
-          // setIdle();
-          // setInitialStellarStore();
-          // openSecondarySidebar('galaxy');
+          setSaveConfirm(false);
         },
         onError: () => {
           alert('CREATE failed');
@@ -43,7 +42,6 @@ export default function SaveButton() {
     }
     // 2. (수정) view 모드, 선택된 stellar 스토어의 userId와 현재 로그인한 userId가 같을 때
     if (mode === 'view' && stellarStore.creator_id === userStore.id) {
-      console.log('view모드 & 작성자 일치 => save버튼 클릭 => 수정');
       updateStellar(
         { stellarId: stellarStore.id, stellarData: stellarStore },
         {
@@ -59,18 +57,35 @@ export default function SaveButton() {
   };
 
   return (
-    <Button
-      color="tertiary"
-      size="sm"
-      onClick={onSaveHandler}
-      disabled={isCreatePending || isUpdatePending}
-    >
-      <FiSave className="w-4 h-4" />
-      {isCreatePending
-        ? 'CREATING...'
-        : isUpdatePending
-          ? 'UPDATING...'
-          : 'SAVE'}
-    </Button>
+    <div>
+      {saveConfirm ? (
+        <div className="flex gap-2">
+          <Button size="sm" color="secondary" onClick={onSaveHandler}>
+            Confirm
+          </Button>
+          <Button
+            size="sm"
+            color="tertiary"
+            onClick={() => setSaveConfirm(false)}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <Button
+          color="tertiary"
+          size="sm"
+          onClick={() => setSaveConfirm(true)}
+          disabled={isCreatePending || isUpdatePending}
+        >
+          <FiSave className="w-4 h-4" />
+          {isCreatePending
+            ? 'CREATING...'
+            : isUpdatePending
+              ? 'UPDATING...'
+              : 'SAVE'}
+        </Button>
+      )}
+    </div>
   );
 }

--- a/src/components/panel/galaxy/community/List.tsx
+++ b/src/components/panel/galaxy/community/List.tsx
@@ -101,7 +101,7 @@ function LoadingComp() {
 function ErrorComp({ resetErrorBoundary }: FallbackProps) {
   return (
     <div className="p-4">
-      <p className="mb-2">에러 발생</p>
+      <p className="mb-2">Error occurred</p>
       <Button color="tertiary" onClick={resetErrorBoundary}>
         다시 시도
       </Button>

--- a/src/components/panel/stellar/info/DeleteStellarButton.tsx
+++ b/src/components/panel/stellar/info/DeleteStellarButton.tsx
@@ -5,8 +5,10 @@ import { useSelectedStellarStore } from '@/stores/useSelectedStellarStore';
 import { useSidebarStore } from '@/stores/useSidebarStore';
 import { useStellarStore } from '@/stores/useStellarStore';
 import { useStellarTabStore } from '@/stores/useStellarTabStore';
+import { useState } from 'react';
 
 export default function DeleteStellarButton() {
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
   const { mutate: deleteStellar, isPending } = useDeleteStellar();
   const { selectedStellarId } = useSelectedStellarStore();
   const { openSecondarySidebar } = useSidebarStore();
@@ -14,31 +16,49 @@ export default function DeleteStellarButton() {
   const { setIdle } = useSelectedStellarStore();
   const { setSelectedObjectId } = useSelectedObjectStore();
   const { setTabValue } = useStellarTabStore();
+
+  const onDeleteHandler = () => {
+    deleteStellar(selectedStellarId, {
+      onSuccess: () => {
+        setDeleteConfirm(false);
+        openSecondarySidebar('galaxy');
+        setInitialStellarStore();
+        setIdle();
+        setSelectedObjectId('');
+        setTabValue('INFO');
+      },
+      onError: () => {
+        alert('DELETE failed');
+      },
+    });
+  };
   return (
-    <Button
-      color="transparent"
-      className="w-full text-text-muted mt-3 text-xs hover:text-error/80"
-      disabled={isPending}
-      onClick={() => {
-        const confirm = window.confirm('DEACTIVATE ACCOUNT');
-        if (confirm) {
-          deleteStellar(selectedStellarId, {
-            onSuccess: () => {
-              alert('DEACTIVATE ACCOUNT success');
-              openSecondarySidebar('galaxy');
-              setInitialStellarStore();
-              setIdle();
-              setSelectedObjectId('');
-              setTabValue('INFO');
-            },
-            onError: () => {
-              alert('DEACTIVATE ACCOUNT failed');
-            },
-          });
-        }
-      }}
-    >
-      DEACTIVATE STELLAR
-    </Button>
+    <div className="w-full mt-3">
+      {deleteConfirm ? (
+        <div className="flex justify-center gap-2">
+          <Button size="sm" color="secondary" onClick={onDeleteHandler}>
+            Confirm
+          </Button>
+          <Button
+            size="sm"
+            color="tertiary"
+            onClick={() => setDeleteConfirm(false)}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <Button
+          color="transparent"
+          className="w-full text-text-muted text-xs hover:text-error/80"
+          disabled={isPending}
+          onClick={() => {
+            setDeleteConfirm(true);
+          }}
+        >
+          DEACTIVATE STELLAR
+        </Button>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## 작업 내용
- 저장/삭제 작업에 확인 단계 추가
- SaveButton, DeleteStellarButton에 확인 다이얼로그 적용
- 커뮤니티 리스트의 에러 메시지를 영어로 변경
- 헤더의 'BACK TO GALAXY' 버튼 조건부 렌더링 로직 개선

## 참고 사항
- 확인 다이얼로그 취소 시 기존 입력값/상태 보존 여부 확인 필요
- 키보드 접근성(포커스 트랩, ESC/Enter 처리) 점검 권장
- i18n 키로 다이얼로그/에러 문구 관리 권장(하드코딩 지양)
- 삭제는 복구 불가 안내 및 실패 시 롤백/토스트 처리 확인
- 라우팅 상태 변화에 따른 'BACK TO GALAXY' 노출 조건 테스트 필요