### PR TITLE
[리팩토링] 목(Mock) 데이터 타입 리팩터링 및 UI 소폭 조정

### DIFF
--- a/src/api/galaxy.ts
+++ b/src/api/galaxy.ts
@@ -14,7 +14,7 @@ function adaptStellarList(res: StellarListResponse): StellarListPage {
     list: data,
     total: meta.total,
     page: meta.page,
-    hasNext: meta.hasNext,
+    limit: meta.limit,
   };
 }
 

--- a/src/components/main/ui/Text.tsx
+++ b/src/components/main/ui/Text.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 type TitleTextProps = {
   children: ReactNode;

--- a/src/mocks/data/galaxiesCommunity.ts
+++ b/src/mocks/data/galaxiesCommunity.ts
@@ -1,10 +1,4 @@
-// src/mocks/data/galaxiesCommunity.ts
-import type {
-  GalaxyCommunityItem,
-  GalaxyCommunityResponse,
-} from '@/types/stellarList';
-
-const data: GalaxyCommunityItem[] = [
+const data = [
   {
     id: 'sys-001',
     title: 'Galaxy 1', // ← galaxyName → title
@@ -80,7 +74,7 @@ const data: GalaxyCommunityItem[] = [
 ];
 
 // 백엔드 원형 응답 형태로 export
-const galaxiesCommunity: GalaxyCommunityResponse = {
+const galaxiesCommunity = {
   data,
   meta: {
     page: 1,

--- a/src/mocks/data/galaxiesMy.ts
+++ b/src/mocks/data/galaxiesMy.ts
@@ -1,7 +1,5 @@
-import type { GalaxyMyData } from '@/types/galaxyMy';
-
 // 더미 데이터 : Galaxy My 리스트
-const galaxyDummy: GalaxyMyData = {
+const galaxyDummy = {
   totalCount: 6,
   list: [
     {

--- a/src/mocks/data/stellar.ts
+++ b/src/mocks/data/stellar.ts
@@ -3,17 +3,11 @@
 
 import { createDefaultProperties } from '../../types/planetProperties';
 import { createDefaultStarProperties } from '../../types/starProperties';
-import type {
-  StellarSystem,
-  Star,
-  Planet,
-  StellarType,
-} from '../../types/stellar';
 
 // === 새로운 Star/Planet 분리 구조 ===
 
 // 항성 모크 데이터
-const mockStar: Star = {
+const mockStar = {
   id: 'star_001',
   object_type: 'STAR',
   system_id: 'system_001',
@@ -29,7 +23,7 @@ const mockStar: Star = {
 };
 
 // 행성들 모크 데이터 (각기 다른 악기 역할)
-const mockPlanets: Planet[] = [
+const mockPlanets = [
   {
     id: 'planet_001',
     object_type: 'PLANET',
@@ -111,17 +105,17 @@ const mockPlanets: Planet[] = [
 ];
 
 // 완전한 스텔라 시스템
-export const mockStellarSystem: StellarSystem = {
+export const mockStellarSystem = {
   id: 'system_001',
   title: 'SONA Demo System',
   galaxy_id: 'galaxy_001', // galaxy_id 추가
   star: mockStar,
   planets: mockPlanets,
   // 원작자 추적 정보 (새로운 필드명 사용)
-  creator_id: 'user_stann_001',         // 현재 소유자
-  author_id: 'user_stann_001',          // 최초 생성자 (원본이므로 생성자와 동일)
-  create_source_id: undefined,          // 클론한 스텔라 (원본이므로 undefined)
-  original_source_id: undefined,        // 최초 스텔라 (원본이므로 undefined)
+  creator_id: 'user_stann_001', // 현재 소유자
+  author_id: 'user_stann_001', // 최초 생성자 (원본이므로 생성자와 동일)
+  create_source_id: undefined, // 클론한 스텔라 (원본이므로 undefined)
+  original_source_id: undefined, // 최초 스텔라 (원본이므로 undefined)
   created_via: 'MANUAL', // 수동 생성
   created_at: '2024-01-01T00:00:00Z',
   updated_at: '2024-01-01T00:00:00Z',
@@ -131,7 +125,7 @@ export const mockStellarSystem: StellarSystem = {
 // === 레거시 호환성 유지 ===
 // 기존 코드가 stellar을 사용하는 경우를 위한 호환성 보장
 
-export const stellar: StellarType = {
+export const stellar = {
   userId: 'testUser', // testUser하면 로그인으로 가정 , bob하면 비로그인으로 가정
   stellarId: 'sys-001',
   stellarName: 'CENTRAL STAR SYSTEM',
@@ -185,25 +179,25 @@ export const stellar: StellarType = {
 };
 
 // 개별 조회를 위한 함수들
-export function getMockStellarSystem(id: string): StellarSystem | undefined {
+export function getMockStellarSystem(id: string) {
   if (id === 'system_001') return mockStellarSystem;
   if (id === 'system_002') return mockClonedStellarSystem;
   return undefined;
 }
 
-export function getMockStar(systemId: string): Star | undefined {
+export function getMockStar(systemId: string) {
   if (systemId === 'system_001') return mockStar;
   if (systemId === 'system_002') return mockClonedStellarSystem.star;
   return undefined;
 }
 
-export function getMockPlanets(systemId: string): Planet[] {
+export function getMockPlanets(systemId: string) {
   if (systemId === 'system_001') return mockPlanets;
   if (systemId === 'system_002') return mockClonedStellarSystem.planets;
   return [];
 }
 
-export function getMockPlanet(planetId: string): Planet | undefined {
+export function getMockPlanet(planetId: string) {
   const allPlanets = [
     ...mockPlanets,
     ...(mockClonedStellarSystem.planets || []),
@@ -213,7 +207,7 @@ export function getMockPlanet(planetId: string): Planet | undefined {
 
 // === 클론된 시스템 예시 (원작자 추적 데모용) ===
 
-const mockClonedStar: Star = {
+const mockClonedStar = {
   id: 'star_002',
   object_type: 'STAR',
   system_id: 'system_002',
@@ -232,7 +226,7 @@ const mockClonedStar: Star = {
   updated_at: '2024-01-02T00:00:00Z',
 };
 
-const mockClonedPlanets: Planet[] = [
+const mockClonedPlanets = [
   {
     id: 'planet_005',
     object_type: 'PLANET',
@@ -262,17 +256,17 @@ const mockClonedPlanets: Planet[] = [
   })),
 ];
 
-export const mockClonedStellarSystem: StellarSystem = {
+export const mockClonedStellarSystem = {
   id: 'system_002',
   title: 'My Version of SONA Demo', // 사용자가 변경한 이름
   galaxy_id: 'galaxy_002', // galaxy_id 추가
   star: mockClonedStar,
   planets: mockClonedPlanets,
   // 클론 추적 정보 (새로운 필드명 사용)
-  creator_id: 'user_alice_002',         // 현재 소유자 (클론한 사람)
-  author_id: 'user_stann_001',          // 최초 생성자 (원작자)
-  create_source_id: 'system_001',       // 클론한 스텔라 (원본 시스템 참조)
-  original_source_id: 'system_001',     // 최초 스텔라 (이 경우 원본과 같음)
+  creator_id: 'user_alice_002', // 현재 소유자 (클론한 사람)
+  author_id: 'user_stann_001', // 최초 생성자 (원작자)
+  create_source_id: 'system_001', // 클론한 스텔라 (원본 시스템 참조)
+  original_source_id: 'system_001', // 최초 스텔라 (이 경우 원본과 같음)
   created_via: 'CLONE', // 클론으로 생성
   created_at: '2024-01-02T00:00:00Z',
   updated_at: '2024-01-02T00:00:00Z',

--- a/src/mocks/data/stellarSystems.ts
+++ b/src/mocks/data/stellarSystems.ts
@@ -1,11 +1,8 @@
-import type { StellarSystem, Star, Planet } from '@/types/stellar';
 import type { StarProperties } from '@/types/starProperties';
 import type { PlanetProperties } from '@/types/planetProperties';
 
 // 목 데이터용 기본 항성 속성
-const createMockStarProperties = (
-  overrides: Partial<StarProperties> = {}
-): StarProperties => ({
+const createMockStarProperties = (overrides: Partial<StarProperties> = {}) => ({
   spin: 50,
   brightness: 75,
   color: 60,
@@ -30,7 +27,7 @@ const createMockPlanetProperties = (
 });
 
 // 목 데이터용 행성들 생성
-const createMockPlanets = (systemId: string): Planet[] => [
+const createMockPlanets = (systemId: string) => [
   {
     id: `${systemId}-planet-1`,
     object_type: 'PLANET',
@@ -110,7 +107,7 @@ const createMockPlanets = (systemId: string): Planet[] => [
 ];
 
 // 목 데이터용 항성들 생성
-const createMockStars = (systemId: string): Star => ({
+const createMockStars = (systemId: string) => ({
   id: `${systemId}-star`,
   object_type: 'STAR',
   system_id: systemId,
@@ -126,7 +123,7 @@ const createMockStars = (systemId: string): Star => ({
 });
 
 // 새로운 StellarSystem 타입에 맞는 목 데이터
-const stellarSystemsMock: StellarSystem[] = [
+const stellarSystemsMock = [
   {
     id: 'sys-001',
     title: 'Stellar System 1',
@@ -227,24 +224,18 @@ const stellarSystemsMock: StellarSystem[] = [
   },
 ];
 
-export const getStellarSystemMock = (
-  stellarId: string
-): StellarSystem | undefined => {
+export const getStellarSystemMock = (stellarId: string) => {
   return stellarSystemsMock.find((stellar) => stellar.id === stellarId);
 };
 
-export const getAllStellarSystemsMock = (): StellarSystem[] => {
+export const getAllStellarSystemsMock = () => {
   return stellarSystemsMock;
 };
 
-export const getStellarSystemsByGalaxyMock = (
-  galaxyId: string
-): StellarSystem[] => {
+export const getStellarSystemsByGalaxyMock = (galaxyId: string) => {
   return stellarSystemsMock.filter((stellar) => stellar.galaxy_id === galaxyId);
 };
 
-export const getStellarSystemsByUserMock = (
-  userId: string
-): StellarSystem[] => {
+export const getStellarSystemsByUserMock = (userId: string) => {
   return stellarSystemsMock.filter((stellar) => stellar.creator_id === userId);
 };

--- a/src/pages/componentstest/Common.tsx
+++ b/src/pages/componentstest/Common.tsx
@@ -16,11 +16,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuLabel,
   DropdownMenuGroup,
-  DropdownMenuSub,
-  DropdownMenuSubTrigger,
-  DropdownMenuSubContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
 } from '@/components/common/DropdownMenu';
 import { ChevronDown, Settings, User, CreditCard, LogOut } from 'lucide-react';
 import Button from '@/components/common/Button';
@@ -35,9 +30,7 @@ import Iconframe from '@/components/common/Iconframe';
 import { SkeletonCard } from '@/components/common/Card/SkeletonCard';
 
 const Common: React.FC = () => {
-  const [checkboxState, setCheckboxState] = useState(false);
   const [sliderValue, setSliderValue] = useState([50]);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   return (
     <div className="min-h-screen bg-background p-8">

--- a/src/pages/componentstest/Panel.tsx
+++ b/src/pages/componentstest/Panel.tsx
@@ -25,7 +25,7 @@ const Panel: React.FC = () => {
           <h2 className="text-2xl font-semibold mb-4 text-foreground">
             System INFO 컴포넌트
           </h2>
-          <Info />
+          <Info isStellarOwner={true} />
         </section>
 
         {/* System PLANETS 컴포넌트 */}


### PR DESCRIPTION
## 작업 내용
- 목데이터 파일에서 명시적 TypeScript 타입 주석 제거로 사용 단순화
- 목데이터 관련 함수 시그니처를 반환 타입 추론 기반으로 정리
- galaxy API의 adaptStellarList에서 프로퍼티 매핑 오류 수정
- 컴포넌트 테스트 파일 UI 소폭 조정
- Info에 isStellarOwner prop 전달 추가
- 불필요한 상태와 import 정리
- Text.tsx에서 ReactNode import를 type 한정자로 변경

## 참고 사항
- 타입 추론 전환으로 인한 외부 사용처(서비스/테스트) 타입 안전성 재확인 필요
- adaptStellarList 매핑 변경이 의존 컴포넌트/훅의 필드 접근에 영향 없는지 점검
- type 전용 import는 TS 설정(모듈 해석, TS 4.5+)에 의존하므로 빌드/바벨 환경 확인
- 변경 후 tsc --noEmit와 주요 렌더 경로 테스트 수행 권장