### PR TITLE
[수정] 메인페이지 Stars component 모듈 import 수정

### DIFF
--- a/src/components/main/canvas/Stars.tsx
+++ b/src/components/main/canvas/Stars.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, Suspense } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Points, PointMaterial } from '@react-three/drei';
 import * as THREE from 'three';
-import * as random from 'maath/random/dist/maath-random.esm';
+import * as random from 'maath/random';
 
 function StarsContent() {
   // 별 포인트 생성 (1000개의 별)
@@ -40,7 +40,7 @@ function StarsContent() {
       {/* 첫 번째 별 레이어 - 가장 큰 별들 */}
       <Points
         ref={starsRef}
-        positions={positions}
+        positions={positions as Float32Array}
         stride={3}
         frustumCulled={false}
       >
@@ -58,7 +58,7 @@ function StarsContent() {
       {/* 두 번째 별 레이어 - 중간 크기 별들 */}
       <Points
         ref={starsRef2}
-        positions={positions}
+        positions={positions as Float32Array}
         stride={3}
         frustumCulled={false}
       >
@@ -76,7 +76,7 @@ function StarsContent() {
       {/* 세 번째 별 레이어 - 작은 별들로 깊이감 추가 */}
       <Points
         ref={starsRef3}
-        positions={positions}
+        positions={positions as Float32Array}
         stride={3}
         frustumCulled={false}
       >


### PR DESCRIPTION
## 작업 내용
- maath/random 임포트를 메인 엔트리 포인트로 변경하여 의존성 경로 단순화
- Points 컴포넌트의 positions prop에 대해 Float32Array로 명시적 타입 캐스팅 추가하여 타입 오류 해결

## 참고 사항
- r3f의 Points는 positions에 Float32Array를 요구하므로, 이후 생성되는 포지션 버퍼도 동일한 타입을 유지해야 함
- 임포트 경로 변경으로 번들링/트리 셰이킹 동작이 달라질 수 있으니 빌드 결과와 번들 크기 변화를 확인 권장