### PR TITLE
[빌드] Vercel에서 SPA 리라이트 규칙 추가

### DIFF
--- a/src/components/cosmos/Planet.tsx
+++ b/src/components/cosmos/Planet.tsx
@@ -30,10 +30,7 @@ export default function Planet({ planet, isSelectable = false }: PlanetProps) {
     return planet.properties[key] ?? defaultValue;
   };
 
-  const cloudTexture = useLoader(
-    THREE.TextureLoader,
-    'public/assets/Clouds2.png'
-  );
+  const cloudTexture = useLoader(THREE.TextureLoader, '/assets/Clouds2.png');
 
   // 필요한 속성들 추출
   const planetSize = getPropertyValue('planetSize', 0.3);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 작업 내용
- client 루트 디렉토리에 vercel.json 추가
- vercel 배포 사이트에서 모든 경로를 index.html로 리라이트하도록 설정

## 참고 사항
- 브라우저에서 /about, /profile 등 직접 접근 시 발생하던 404 문제 해결 (클라이언트 사이드 라우팅 정상 동작)