### PR TITLE
[리팩토링] 쿼리 클라이언트 옵션 업데이트 및 StellarWritePayload의 position 필드 주석 처리

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -6,7 +6,11 @@ import { QueryClient } from '@tanstack/react-query';
 export default new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
+      staleTime: 1000 * 60 * 2, // 2분 동안 fresh로 취급 (기본값 0 : 마운트 마다 재요청)
+      gcTime: 1000 * 60 * 10, // 비활성시 10분간 캐시 유지
+      refetchOnWindowFocus: false, // 창 포커스 시 재요청 비활성 (이미 해두셨음)
+      refetchOnMount: false, // 마운트 시 stale 여부와 관계없이 재요청 막기
+      refetchOnReconnect: false,
       retry: 0,
     },
   },

--- a/src/types/stellarWrite.ts
+++ b/src/types/stellarWrite.ts
@@ -6,7 +6,7 @@ import type { StarProperties } from '@/types/starProperties';
 export type StellarWritePayload = {
   title: string;
   galaxy_id: string;
-  position: [number, number, number];
+  // position: [number, number, number];
   star: {
     name: string;
     properties: StarProperties; // 스토어 값 그대로
@@ -36,7 +36,7 @@ export function toStellarWritePayload(
   return {
     title: system.title,
     galaxy_id: system.galaxy_id,
-    position: system.position,
+    // position: system.position,
     star: {
       name: system.star.name,
       properties: system.star.properties, // 그대로


### PR DESCRIPTION
## 작업 내용
- React Query 기본 옵션에 staleTime 및 gcTime(캐시 유지/가비지 수집 관련 설정) 추가.
- refetchOnMount 및 refetchOnReconnect 동작을 비활성화하여 불필요한 백그라운드 재요청 차단.
- StellarWritePayload 타입의 position 필드와 해당 필드를 사용하는 관련 함수들을 주석 처리(향후 제거 또는 리팩토링 대상으로 표시).

## 참고 사항
- staleTime/gcTime 설정으로 빈번한 네트워크 요청을 줄이고 UX를 개선할 수 있음. 환경별(개발/프로덕션)로 값 차등 적용을 고려할 것.
- refetchOnMount/refetchOnReconnect 비활성화는 데이터를 즉시 최신으로 받아야 하는 시나리오엔 부적합할 수 있으니, 실시간성이 필요한 쿼리는 개별 옵션으로 예외 처리할 것.
- position 필드를 주석 처리함에 따라 해당 필드에 의존하는 코드(프론트/백엔드 계약, DB 스키마, 테스트 케이스 등)를 점검해야 함. 제거 결정 전에는 다음을 확인하길 권장:
- 코드베이스 전역에서 position 사용처 검색 및 영향 범위 파악
- API 스펙(백엔드)과의 호환성 확인
- 관련 유닛·통합 테스트 업데이트/검증
- 이 변경을 추적하는 이슈/PR 코멘트로 의도(임시 주석 vs 완전 제거)를 명확히 남길 것
- 검증 방법: React Query Devtools로 isStale/fetch 동작 확인, 네트워크 탭에서 불필요한 요청 감소 여부 확인, 주석 처리한 필드 사용 시 컴파일/런타임 에러 여부 점검.