### PR TITLE
[리팩토링] queryClient 기본 쿼리 옵션 단순화

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -6,11 +6,7 @@ import { QueryClient } from '@tanstack/react-query';
 export default new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 2, // 2분 동안 fresh로 취급 (기본값 0 : 마운트 마다 재요청)
-      gcTime: 1000 * 60 * 10, // 비활성시 10분간 캐시 유지
-      refetchOnWindowFocus: false, // 창 포커스 시 재요청 비활성 (이미 해두셨음)
-      refetchOnMount: false, // 마운트 시 stale 여부와 관계없이 재요청 막기
-      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
       retry: 0,
     },
   },


### PR DESCRIPTION
## 작업 내용
- lib/queryClient.ts의 기본 쿼리 설정에서 staleTime, gcTime, refetchOnMount, refetchOnReconnect 등 커스텀 옵션 제거.
- 기본으로 남긴 옵션은 refetchOnWindowFocus와 retry만 유지하도록 변경.
- 전역 설정을 간소화하여 query client 초기 설정을 단순화함.

## 참고 사항
- 제거로 인해 해당 항목들은 이제 react-query의 기본 동작을 따릅니다(예: staleTime은 기본값 0 — 필요 시 개별 쿼리에서 설정 권장).
- 목록 등 빈번히 호출되는 쿼리는 필요에 따라 개별 훅에서 staleTime/refetchOnMount 등을 명시적으로 설정해서 성능/네트워크 트레이드오프를 조절할 것.
- 변경 후 네트워크 호출 빈도나 UX 영향(백그라운드 재요청 등)을 모니터링하고, 문제가 발견되면 해당 쿼리만 예외 처리하는 방식으로 보완 권장.