### PR TITLE
[기능] OBJECT 삭제 버튼 추가, 스텔라 CREATE 시 random 프로퍼티로 생성, CREATE 성공 시 stellar Id값 스토어에 저장

### DIFF
--- a/src/components/layout/Header/SaveButton.tsx
+++ b/src/components/layout/Header/SaveButton.tsx
@@ -14,7 +14,7 @@ export default function SaveButton() {
   const { mutate: updateStellar, isPending: isUpdatePending } =
     useUpdateStellar();
   const { mode } = useSelectedStellarStore();
-  const { stellarStore } = useStellarStore();
+  const { stellarStore, setStellarStore } = useStellarStore();
   const { userStore, isLoggedIn } = useUserStore();
 
   // save 버튼 동작 기준
@@ -32,11 +32,12 @@ export default function SaveButton() {
     }
 
     // 1. (생성) create 모드
-    // 완료 시 => selectedStellarStore 초기화 & stellarStore 초기화 & 갤럭시 패널 이동
+    // 완료 시 => selectedStellarStore 초기화 & stellarStore 초기화 & 갤럭시 패널 이동 & id 추가(중복 생성 방지)
     if (mode === 'create') {
       createStellar(stellarStore, {
-        onSuccess: () => {
+        onSuccess: (data) => {
           setSaveConfirm(false);
+          setStellarStore({ ...data, id: data.id });
         },
         onError: () => {
           alert('CREATE failed');

--- a/src/components/panel/galaxy/community/CardItem.tsx
+++ b/src/components/panel/galaxy/community/CardItem.tsx
@@ -6,6 +6,7 @@ import type { StellarListItem } from '@/types/stellarList';
 import { useLikeToggle } from '@/hooks/api/useLikes';
 import { formatDateToYMD } from '@/utils/formatDateToYMD';
 import { useUserStore } from '@/stores/useUserStore';
+import Button from '@/components/common/Button';
 
 interface CardItemProps extends StellarListItem {
   onClick: () => void;
@@ -15,6 +16,7 @@ export default function CardItem({
   id,
   rank,
   title,
+  creator_id,
   creator_name,
   updated_at,
   planet_count,
@@ -27,30 +29,52 @@ export default function CardItem({
   const { likeStatus, toggleLike, isPending } = useLikeToggle(id, is_liked);
 
   return (
-    <Card onClick={onClick} role="button">
+    <Card
+      onClick={onClick}
+      role="button"
+      className="hover:bg-white/10 hover:brightness-110"
+    >
       <div className="flex items-center justify-between min-w-0 w-full max-w-full">
         {/* ← 왼쪽 영역: 줄어들 수 있게 basis-0 grow min-w-0 */}
         <div className="basis-0 grow min-w-0">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex gap-2 min-w-0">
             <span className="text-text-muted flex-shrink-0">#{rank}</span>
-            <strong className="text-white w-0 flex-1 truncate">{title}</strong>
+            <strong className="text-white w-0 flex-1 line-clamp-2">
+              {title}
+            </strong>
           </div>
 
-          <div className="mt-3 min-w-0 w-full space-y-1 text-[12px] text-text-muted">
+          <div className="mt-2 min-w-0 w-full space-y-1 text-text-muted">
             <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'auto 1fr',
-                gap: '4px',
-              }}
-              className="min-w-0 w-full"
+              className="flex items-center min-w-0 w-full overflow-hidden"
+              // style={{
+              //   display: 'grid',
+              //   gridTemplateColumns: 'auto 1fr',
+              //   gap: '4px',
+              //   alignItems: 'center',
+              //   justifyContent: 'center',
+              // }}
             >
-              <span>BY</span>
-              <span className="truncate text-primary-300">{creator_name}</span>
+              <span className="text-sm inline-block">by</span>
+              <Button
+                color="transparent"
+                size="xxs"
+                className="p-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  console.log('해당 유저의 프로필로 이동');
+                  console.log('creator_id : ', creator_id);
+                  console.log('creator_name : ', creator_name);
+                }}
+              >
+                <span className="inline-block max-w-[calc(147px-16px)] overflow-hidden text-ellipsis text-[14px] font-bold text-primary-300 hover:underline transition-all transition-duration-300 rounded-[2px]">
+                  {creator_name}
+                </span>
+              </Button>
             </div>
 
             {/* 날짜 */}
-            <div className="grid grid-cols-[auto,1fr] gap-1 min-w-0 w-full">
+            <div className="grid grid-cols-[auto,1fr] gap-1 min-w-0 w-full text-xs mt-2">
               <span className="truncate">{formatDateToYMD(updated_at)}</span>
             </div>
           </div>
@@ -58,7 +82,7 @@ export default function CardItem({
 
         {isLoggedIn && (
           <ButtonLike
-            className="flex-shrink-0 ml-3"
+            className="flex-shrink-0"
             active={likeStatus}
             onClick={toggleLike}
             isPending={isPending}
@@ -66,7 +90,7 @@ export default function CardItem({
         )}
       </div>
 
-      <div className="mt-3 flex gap-4">
+      <div className="mt-2 flex gap-4">
         <div>
           <IoPlanetOutline className="inline-block w-[12px] h-[16px] mr-1" />
           {planet_count}

--- a/src/components/panel/galaxy/my/CardItem.tsx
+++ b/src/components/panel/galaxy/my/CardItem.tsx
@@ -20,7 +20,9 @@ export default function CardItem({
       <div className="flex items-center justify-between min-w-0">
         <div className="flex-1 min-w-0">
           <div className="flex items-center text-[14px] font-bold min-w-0">
-            <strong className="text-white w-0 flex-1 truncate">{title}</strong>
+            <strong className="text-white w-0 flex-1 line-clamp-2">
+              {title}
+            </strong>
           </div>
           <div className="mt-3 flex flex-col items-start gap-1 text-[12px] text-text-muted">
             <span>{formatDateToYMD(updated_at)}</span>

--- a/src/components/panel/stellar/info/DeleteStellarButton.tsx
+++ b/src/components/panel/stellar/info/DeleteStellarButton.tsx
@@ -36,15 +36,21 @@ export default function DeleteStellarButton() {
     <div className="w-full mt-3">
       {deleteConfirm ? (
         <div className="flex justify-center gap-2">
-          <Button size="sm" color="secondary" onClick={onDeleteHandler}>
-            Confirm
+          <Button
+            size="lg"
+            color="transparent"
+            onClick={onDeleteHandler}
+            className="text-xs hover:text-error/80"
+          >
+            DELETE
           </Button>
           <Button
-            size="sm"
-            color="tertiary"
+            size="lg"
+            color="transparent"
             onClick={() => setDeleteConfirm(false)}
+            className="text-xs hover:text-white"
           >
-            Cancel
+            CANCEL
           </Button>
         </div>
       ) : (

--- a/src/components/panel/stellar/info/StellarInfo.tsx
+++ b/src/components/panel/stellar/info/StellarInfo.tsx
@@ -34,8 +34,8 @@ export default function StellarInfo({
     STAR_NAME: stellarStore.star.name,
     CREATOR: stellarStore.creator_name,
     AUTHOR: stellarStore.author_name,
-    ['CREATE SOURCE']: 'ORIGINAL COMPOSITION',
-    ['ORIGINAL SOURCE']: 'SONA STUDIO',
+    ['CREATE SOURCE']: stellarStore.title,
+    ['ORIGINAL SOURCE']: stellarStore.title,
   };
 
   // 4) 최종 표시 대상: 선택이 스타이거나, 매칭되는 플래닛이 없으면 스타로 fallback

--- a/src/components/panel/stellar/objects/Objects.tsx
+++ b/src/components/panel/stellar/objects/Objects.tsx
@@ -53,7 +53,6 @@ function ObjectsContent() {
                 key={data.id}
                 data={data}
                 onClick={() => {
-                  console.log('=================data.id', data.id);
                   setSelectedObjectId(data.id);
                 }}
                 active={selectedObjectId === data.id}

--- a/src/components/panel/stellar/objects/StellarCard.tsx
+++ b/src/components/panel/stellar/objects/StellarCard.tsx
@@ -1,8 +1,12 @@
+import Button from '@/components/common/Button';
 import Card from '@/components/common/Card/Card';
 import type { Star, Planet } from '@/types/stellar';
 import { mergeClassNames } from '@/utils/mergeClassNames';
 import { valueToColor } from '@/utils/valueToColor';
 import { FaStar } from 'react-icons/fa';
+import { RiDeleteBinLine } from 'react-icons/ri';
+import { useStellarStore } from '@/stores/useStellarStore';
+import { useSelectedObjectStore } from '@/stores/useSelectedObjectStore';
 
 interface StellarCardProps {
   data: Star | Planet;
@@ -19,6 +23,9 @@ export default function StellarCard({
   className,
   name,
 }: StellarCardProps) {
+  const { deletePlanet, stellarStore } = useStellarStore();
+  const { setSelectedObjectId } = useSelectedObjectStore();
+
   const description =
     data.object_type === 'PLANET' ? 'PLANET • ' + data.role : 'CENTRAL STAR';
 
@@ -60,11 +67,28 @@ export default function StellarCard({
           </strong>
           <p className="text-text-muted">{description}</p>
         </div>
-        {/* 별자리 아이콘 : STAR 경우만 */}
-        {data.object_type === 'STAR' && (
-          <div className="w-[24px] h-[24px] shrink-0 text-[#FACC15]">
+
+        {/* STAR 경우 : 별자리 아이콘 / PLANET 경우 : 삭제 버튼튼 */}
+        {data.object_type === 'STAR' ? (
+          <div className="flex items-center justify-center w-[24px] h-[24px] shrink-0 text-[#FACC15]">
             <FaStar />
           </div>
+        ) : (
+          <Button
+            color="transparent"
+            iconOnly
+            className="w-[24px] h-[24px] shrink-0 hover:[&_svg]:!text-error/80 hover:[&_svg]:!fill-error/80"
+            onClick={(e) => {
+              e.stopPropagation();
+
+              // stellarStore에서 해당 planet 삭제
+              deletePlanet(data.id);
+              // 현재 선택된 stellar의 star의 id로 대체
+              setSelectedObjectId(stellarStore.star.id);
+            }}
+          >
+            <RiDeleteBinLine className="w-full h-full" />
+          </Button>
         )}
       </div>
     </Card>

--- a/src/components/panel/stellar/properties/Random.tsx
+++ b/src/components/panel/stellar/properties/Random.tsx
@@ -1,82 +1,50 @@
 import Button from '@/components/common/Button';
-// ❌ minMaxRandomNo는 정수 전용이라 제거
-// import minMaxRandomNo from '@/utils/minMaxRandomNo';
-import { useSelectedObjectStore } from '@/stores/useSelectedObjectStore';
 import { useStellarStore } from '@/stores/useStellarStore';
 import type { Star, Planet } from '@/types/stellar';
 import {
-  PLANET_PROPERTIES,
-  type PlanetProperties,
-} from '@/types/planetProperties';
-import type { StarProperties } from '@/types/starProperties';
+  createRandomStarProperties,
+  createRandomPlanetProperties,
+} from '@/utils/randomProperties';
 
 interface RandomProps {
-  target: Star | Planet; // Star 또는 Planet 전체 객체
-}
-
-// step/precision 반영 랜덤 유틸 (컴포넌트 내부에 둠)
-function randStep(min: number, max: number, step = 1, precision?: number) {
-  const steps = Math.floor((max - min) / step);
-  const k = Math.floor(Math.random() * (steps + 1));
-  const v = min + k * step;
-  return precision != null ? +v.toFixed(precision) : v;
+  target: Star | Planet;
 }
 
 export default function Random({ target }: RandomProps) {
-  const { selectedObjectId } = useSelectedObjectStore();
   const { stellarStore, setStellarStore } = useStellarStore();
 
   if (!target) return null;
 
   const handleRandomClick = () => {
     if (target.object_type === 'STAR') {
-      // === STAR: 기존 로직 유지 ===
-      const randomized: StarProperties = {
-        spin: Math.floor(Math.random() * 101), // 0~100
-        brightness: Math.floor(Math.random() * 101), // 0~100
-        color: Math.floor(Math.random() * 361), // 0~360
-        size: Math.floor(Math.random() * 101), // 0~100
-      };
-
       setStellarStore({
         ...stellarStore,
         star: {
-          ...stellarStore.star!,
-          properties: randomized,
+          ...stellarStore.star,
+          properties: createRandomStarProperties(),
         },
       });
     } else {
-      // === PLANET: step/precision 반영 랜덤 ===
-      const randomized = Object.entries(PLANET_PROPERTIES).reduce(
-        (acc, [key, def]) => {
-          // 서버 제약 보호: inclination은 ±90으로 제한 (원하면 삭제 가능)
-          const min = key === 'inclination' ? Math.max(def.min, -90) : def.min;
-          const max = key === 'inclination' ? Math.min(def.max, 90) : def.max;
-
-          (acc as PlanetProperties)[key] = randStep(
-            min,
-            max,
-            def.step ?? 1,
-            def.precision
-          );
-          return acc;
-        },
-        {} as PlanetProperties
-      );
+      const targetId = target.id; // 선택 스토어 대신 실제 타겟 보장
+      const randomized = createRandomPlanetProperties();
 
       setStellarStore({
         ...stellarStore,
-        planets: stellarStore.planets.map((planet) =>
-          planet.id === selectedObjectId
-            ? { ...planet, properties: randomized }
-            : planet
+        planets: stellarStore.planets.map((p) =>
+          p.id === targetId ? { ...p, properties: randomized } : p
         ),
       });
     }
   };
 
   return (
-    <Button color="secondary" size="xs" onClick={handleRandomClick}>
+    <Button
+      color="secondary"
+      size="xs"
+      onClick={() => {
+        handleRandomClick();
+      }}
+    >
       RANDOM
     </Button>
   );

--- a/src/types/stellarList.ts
+++ b/src/types/stellarList.ts
@@ -4,7 +4,7 @@ export interface StellarListItem {
   id: string;
   title: string;
   galaxy_id: string;
-  // creator_id: string;
+  creator_id: string;
   creator_name: string;
   created_at: string;
   updated_at: string;

--- a/src/types/stellarWrite.ts
+++ b/src/types/stellarWrite.ts
@@ -4,6 +4,7 @@ import type { StarProperties } from '@/types/starProperties';
 
 // ⭐ 스텔라 스토어 -> 스텔라 백엔드 페이로드 변경해서 보냄
 export type StellarWritePayload = {
+  id: string;
   title: string;
   galaxy_id: string;
   // position: [number, number, number];
@@ -34,6 +35,7 @@ export function toStellarWritePayload(
   system: StellarSystem
 ): StellarWritePayload {
   return {
+    id: system.id,
     title: system.title,
     galaxy_id: system.galaxy_id,
     // position: system.position,

--- a/src/utils/createStarPlantId.ts
+++ b/src/utils/createStarPlantId.ts
@@ -1,0 +1,22 @@
+// src/utils/createId.ts
+export type IdPrefix = 'planet' | 'star' | 'system' | 'id';
+export type BrandedId<P extends IdPrefix = 'id'> = `${P}_${string}`;
+
+export function createId<P extends IdPrefix = 'id'>(
+  prefix: P = 'id' as P
+): BrandedId<P> {
+  const g: any = globalThis as any; // eslint-disable-line
+
+  if (g.crypto?.randomUUID) {
+    return `${prefix}_${g.crypto.randomUUID()}` as BrandedId<P>;
+  }
+
+  // 폴백: 시간기반 + 난수(base36)
+  const ts = Date.now().toString(36); // 가독성 좋은 짧은 타임스탬프
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `${prefix}_${ts}${rand}` as BrandedId<P>;
+}
+
+// 편의 함수
+export const createPlanetId = () => createId('planet'); // → `${'planet'}_${string}`
+export const createStarId = () => createId('star');

--- a/src/utils/randomProperties.ts
+++ b/src/utils/randomProperties.ts
@@ -1,0 +1,86 @@
+// src/utils/randomProperties.ts
+import type { StarProperties } from '@/types/starProperties';
+import {
+  PLANET_PROPERTIES,
+  type PlanetProperties,
+} from '@/types/planetProperties';
+
+// 공통: step/precision 반영 난수
+export function randStep(
+  min: number,
+  max: number,
+  step = 1,
+  precision?: number
+) {
+  const steps = Math.floor((max - min) / step);
+  const k = Math.floor(Math.random() * (steps + 1));
+  const v = min + k * step;
+  return precision != null ? +v.toFixed(precision) : v;
+}
+
+// Star용 정의(원하시면 별도 상수로 외부 분리 가능)
+const STAR_DEFS: Record<
+  keyof StarProperties,
+  { min: number; max: number; step?: number; precision?: number }
+> = {
+  spin: { min: 0, max: 100, step: 1 },
+  brightness: { min: 0, max: 100, step: 1 },
+  color: { min: 0, max: 360, step: 1 },
+  size: { min: 0.1, max: 2.0, step: 0.1, precision: 1 }, // 예: 소수1자리
+};
+
+export function createRandomStarProperties(): StarProperties {
+  return {
+    spin: randStep(
+      STAR_DEFS.spin.min,
+      STAR_DEFS.spin.max,
+      STAR_DEFS.spin.step,
+      STAR_DEFS.spin.precision
+    ),
+    brightness: randStep(
+      STAR_DEFS.brightness.min,
+      STAR_DEFS.brightness.max,
+      STAR_DEFS.brightness.step,
+      STAR_DEFS.brightness.precision
+    ),
+    color: randStep(
+      STAR_DEFS.color.min,
+      STAR_DEFS.color.max,
+      STAR_DEFS.color.step,
+      STAR_DEFS.color.precision
+    ),
+    size: randStep(
+      STAR_DEFS.size.min,
+      STAR_DEFS.size.max,
+      STAR_DEFS.size.step,
+      STAR_DEFS.size.precision
+    ),
+  };
+}
+
+// Planet용: PLANET_PROPERTIES 기반으로 전 필드 생성
+export function createRandomPlanetProperties(opts?: {
+  clampInclination?: boolean;
+}): PlanetProperties {
+  const { clampInclination = true } = opts ?? {};
+  const out = {} as PlanetProperties;
+
+  (
+    Object.entries(PLANET_PROPERTIES) as [
+      keyof PlanetProperties,
+      { min: number; max: number; step?: number; precision?: number },
+    ][]
+  ).forEach(([key, def]) => {
+    const min =
+      clampInclination && key === 'inclination'
+        ? Math.max(def.min, -90)
+        : def.min;
+    const max =
+      clampInclination && key === 'inclination'
+        ? Math.min(def.max, 90)
+        : def.max;
+    (out as any)[key] = randStep(min, max, def.step ?? 1, def.precision); // eslint-disable-line
+  });
+
+  return out;
+}


### PR DESCRIPTION
## 작업 내용
- Star/Planet 프로퍼티 랜덤 생성 유틸 추가 (createRandomStarProperties, createRandomPlanetProperties)
- 유니크 ID 생성 유틸 도입 및 스토어 적용 (createPlanetId), 증분 번호 기반 ID 제거
- 스토어 리팩터링: setInitialStellarStore, addNewObjectAndReturnId가 랜덤 프로퍼티를 사용하도록 변경
- 플래닛 삭제 로직 추가 및 안전장치 적용(최소 1개 플래닛 보장)
- UI 컴포넌트 업데이트: 프로퍼티 랜덤 버튼 연결, 삭제 버튼 동작, 크리에이터 정보 표시 개선
- 타입 보강: 누락 필드 추가 및 백엔드 전송 페이로드 구조 정합성 확보

## 참고 사항
- ID 형식이 변경되어(MSW/목데이터) 기존 고정 ID 의존 코드/테스트가 있으면 업데이트 필요
- 초기 생성/추가 시 프로퍼티가 랜덤으로 세팅되므로 시드 고정이 필요한 경우 별도 처리 필요
- 플래닛 최소 1개 규칙으로 인해 마지막 항목은 삭제되지 않음(UX/기획 확인 요망)
- PLANET_PROPERTIES의 min/max/step/precision 정의가 필수이므로 스키마 변경 시 유틸도 함께 점검