### PR TITLE
[리팩토링] CREATE 모드에서 스텔라 SAVE 시 '수정'모드로 전환, community 리스트에서 카드의 유저name 클릭시 해당 유저profile화면으로 이동

### DIFF
--- a/src/components/layout/Header/SaveButton.tsx
+++ b/src/components/layout/Header/SaveButton.tsx
@@ -5,6 +5,7 @@ import { useSelectedStellarStore } from '@/stores/useSelectedStellarStore';
 import { useStellarStore } from '@/stores/useStellarStore';
 import { useUserStore } from '@/stores/useUserStore';
 import { useState } from 'react';
+import useStellarSystemSelection from '@/hooks/useStellarSystemSelection';
 
 export default function SaveButton() {
   const [saveConfirm, setSaveConfirm] = useState(false);
@@ -14,8 +15,10 @@ export default function SaveButton() {
   const { mutate: updateStellar, isPending: isUpdatePending } =
     useUpdateStellar();
   const { mode } = useSelectedStellarStore();
-  const { stellarStore, setStellarStore } = useStellarStore();
+  const { stellarStore } = useStellarStore();
   const { userStore, isLoggedIn } = useUserStore();
+
+  const { selectStellar } = useStellarSystemSelection();
 
   // save 버튼 동작 기준
   const onSaveHandler = () => {
@@ -37,7 +40,7 @@ export default function SaveButton() {
       createStellar(stellarStore, {
         onSuccess: (data) => {
           setSaveConfirm(false);
-          setStellarStore({ ...data, id: data.id });
+          selectStellar(data.id);
         },
         onError: () => {
           alert('CREATE failed');

--- a/src/components/panel/galaxy/community/CardItem.tsx
+++ b/src/components/panel/galaxy/community/CardItem.tsx
@@ -7,6 +7,8 @@ import { useLikeToggle } from '@/hooks/api/useLikes';
 import { formatDateToYMD } from '@/utils/formatDateToYMD';
 import { useUserStore } from '@/stores/useUserStore';
 import Button from '@/components/common/Button';
+import { navigateToOtherUserProfile } from '@/utils/profileNavigation';
+import { useSidebarStore } from '@/stores/useSidebarStore';
 
 interface CardItemProps extends StellarListItem {
   onClick: () => void;
@@ -25,6 +27,7 @@ export default function CardItem({
   onClick,
 }: CardItemProps) {
   const { isLoggedIn } = useUserStore();
+  const { openSecondarySidebar } = useSidebarStore();
   // 통합된 좋아요 훅 사용 - 중복 로직 제거
   const { likeStatus, toggleLike, isPending } = useLikeToggle(id, is_liked);
 
@@ -45,16 +48,7 @@ export default function CardItem({
           </div>
 
           <div className="mt-2 min-w-0 w-full space-y-1 text-text-muted">
-            <div
-              className="flex items-center min-w-0 w-full overflow-hidden"
-              // style={{
-              //   display: 'grid',
-              //   gridTemplateColumns: 'auto 1fr',
-              //   gap: '4px',
-              //   alignItems: 'center',
-              //   justifyContent: 'center',
-              // }}
-            >
+            <div className="flex items-center min-w-0 w-full overflow-hidden">
               <span className="text-sm inline-block">by</span>
               <Button
                 color="transparent"
@@ -64,7 +58,10 @@ export default function CardItem({
                   e.stopPropagation();
                   console.log('해당 유저의 프로필로 이동');
                   console.log('creator_id : ', creator_id);
-                  console.log('creator_name : ', creator_name);
+                  // 1. 프로필 컴포넌트를 유저id에 맞게 변경
+                  navigateToOtherUserProfile(creator_id);
+                  // 2. sideBarProfile 패널 열기
+                  openSecondarySidebar('profile');
                 }}
               >
                 <span className="inline-block max-w-[calc(147px-16px)] overflow-hidden text-ellipsis text-[14px] font-bold text-primary-300 hover:underline transition-all transition-duration-300 rounded-[2px]">

--- a/src/types/stellarWrite.ts
+++ b/src/types/stellarWrite.ts
@@ -4,7 +4,6 @@ import type { StarProperties } from '@/types/starProperties';
 
 // ⭐ 스텔라 스토어 -> 스텔라 백엔드 페이로드 변경해서 보냄
 export type StellarWritePayload = {
-  id: string;
   title: string;
   galaxy_id: string;
   // position: [number, number, number];
@@ -35,7 +34,6 @@ export function toStellarWritePayload(
   system: StellarSystem
 ): StellarWritePayload {
   return {
-    id: system.id,
     title: system.title,
     galaxy_id: system.galaxy_id,
     // position: system.position,


### PR DESCRIPTION
## 작업 내용
- SaveButton: 직접 스토어 업데이트 대신 selectStellar 사용으로 상태 관리 일원화
- CardItem: 크리에이터 이름 클릭 시 navigateToOtherUserProfile로 이동 및 프로필 사이드바 오픈
- Payload 정리: StellarWritePayload에서 id 필드 및 관련 변환 함수 제거

## 참고 사항
- StellarWritePayload 타입 변경에 따른 API/핸들러/목데이터/테스트 의존성 업데이트 필요
- selectStellar 도입으로 기존 setStellarStore 기반 저장 흐름을 쓰는 컴포넌트는 교체 검토
- 프로필 사이드바 오픈 로직은 라우팅/전역 상태 스토어 의존성 확인 필요