### PR TITLE
[리팩토링] 스텔라 초기화/생성 시 PLANET DETAILS 랜덤 properties 적용

### DIFF
--- a/src/stores/useStellarStore.ts
+++ b/src/stores/useStellarStore.ts
@@ -1,4 +1,4 @@
-// src/stores/useStellarSystemStore.ts
+// src/stores/useStellarStore.ts
 import { create } from 'zustand';
 import type {
   StellarSystem,
@@ -6,13 +6,20 @@ import type {
   Planet,
   InstrumentRole,
 } from '@/types/stellar';
-import type { StarProperties } from '@/types/starProperties';
-import type { PlanetProperties } from '@/types/planetProperties';
+import {
+  type StarProperties,
+  createDefaultStarProperties,
+} from '@/types/starProperties';
+import {
+  type PlanetProperties,
+  createDefaultProperties,
+} from '@/types/planetProperties';
 import { useUserStore } from '@/stores/useUserStore';
-import { createDefaultProperties } from '@/types/planetProperties';
 import {
   getDefaultSynthType,
   getDefaultOscillatorType,
+  type SynthTypeId,
+  type OscillatorTypeId,
 } from '@/audio/instruments/InstrumentInterface';
 import { formatDateToYMD } from '@/utils/formatDateToYMD';
 import { createPlanetId } from '@/utils/createStarPlantId';
@@ -20,18 +27,69 @@ import {
   createRandomPlanetProperties,
   createRandomStarProperties,
 } from '@/utils/randomProperties';
+import { createRandomPlanetInstrument } from '@/utils/randomPlanetDetails';
 
-/***** 1) 기본 프로퍼티 디폴트 *****/
-const defaultStarProps: StarProperties = {
-  spin: 50,
-  brightness: 1,
-  color: 1,
-  size: 1.0, // 적절한 크기 범위 (0.1 ~ 2.0)
-};
+/***** 공통 상수/헬퍼 *****/
+const DEFAULT_ROLE: InstrumentRole = 'DRUM';
+const nowYMD = () => formatDateToYMD();
 
+/** 초기 Star 오브젝트(랜덤 프로퍼티 포함) 생성 */
+function makeInitStar(overrides?: Partial<Star>): Star {
+  const now = nowYMD();
+  return {
+    ...(initialStellarStore.star as Star),
+    system_id: '',
+    properties: createRandomStarProperties(),
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+/** 초기 Planet 오브젝트(랜덤 프로퍼티 + PLANET DETAILS 포함) 생성 */
+function makeInitPlanet(params?: {
+  id?: string;
+  systemId?: string;
+  role?: InstrumentRole;
+  name?: string;
+  planetDetails?: {
+    role: InstrumentRole;
+    synthType: SynthTypeId;
+    oscillatorType: OscillatorTypeId;
+  };
+}): Planet {
+  const id = params?.id ?? createPlanetId();
+  const systemId = params?.systemId ?? '';
+  const name = params?.name ?? 'NEW PLANET';
+  const now = nowYMD();
+
+  // planetDetails가 주어지면 사용, 아니면 (role 또는 기본 역할) 기준으로 폴백
+  const chosenRole =
+    params?.planetDetails?.role ?? params?.role ?? DEFAULT_ROLE;
+  const synth =
+    params?.planetDetails?.synthType ?? getDefaultSynthType(chosenRole);
+  const oscillator =
+    params?.planetDetails?.oscillatorType ??
+    getDefaultOscillatorType(chosenRole, synth);
+
+  return {
+    id,
+    object_type: 'PLANET',
+    system_id: systemId,
+    name,
+    role: chosenRole,
+    properties: createRandomPlanetProperties(),
+    synthType: synth,
+    oscillatorType: oscillator,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+/***** 1) 기본 프로퍼티 디폴트 (템플릿 보존) *****/
+const defaultStarProps: StarProperties = createDefaultStarProperties();
 export const defaultPlanetProps: PlanetProperties = createDefaultProperties();
 
-/***** 2) 초기 스텔라 시스템 *****/
+/***** 2) 초기 스텔라 시스템 (템플릿) *****/
 export const initialStellarStore: StellarSystem = {
   id: '',
   title: 'NEW STELLAR SYSTEM',
@@ -47,14 +105,12 @@ export const initialStellarStore: StellarSystem = {
   creator_name: '',
   create_source_name: '',
   original_source_name: '',
-
-  // 빈 항성 및 행성 배열로 초기화
   star: {
     id: 'star_001',
     object_type: 'STAR',
     system_id: '',
     name: 'Central Star',
-    properties: defaultStarProps,
+    properties: defaultStarProps, // 실제 초기화 시엔 makeInitStar가 랜덤으로 교체
     created_at: formatDateToYMD(),
     updated_at: formatDateToYMD(),
   },
@@ -71,33 +127,32 @@ interface StellarStore {
   deletePlanet: (planetId: string) => boolean;
 }
 
-// ===== 구현 =====
+/***** 구현 *****/
 export const useStellarStore = create<StellarStore>((set, get) => ({
   stellarStore: initialStellarStore,
 
   setStellarStore: (stellarStore) =>
-    set(() => {
-      return {
-        stellarStore: {
-          ...stellarStore,
-          updated_at: formatDateToYMD(),
-        },
-      };
-    }),
+    set(() => ({
+      stellarStore: { ...stellarStore, updated_at: nowYMD() },
+    })),
 
   setInitialStellarStore: () =>
     set((state) => {
-      // 작성자/소유자 계열 필드를 userId 기반으로 세팅 => 비로그인 경우 '' 빈 값
-      // 훅 호출하지 않고, 스토어 인스턴스의 getState() 사용
       const userId = useUserStore.getState().userStore.id ?? '';
-      const now = formatDateToYMD();
       const userName = useUserStore.getState().userStore.username ?? '';
-      console.log('userName', userName);
+      const now = nowYMD();
 
-      const role: InstrumentRole = 'DRUM';
-      const defaultSynth = getDefaultSynthType(role);
+      // STAR/첫 번째 PLANET 생성
+      const star = makeInitStar();
 
-      const newPlanetId = createPlanetId();
+      // ✅ 요청: planetDetails 변수 사용 (랜덤 악기 구성)
+      const planetDetails = createRandomPlanetInstrument();
+      const firstPlanetId = createPlanetId();
+      const firstPlanet = makeInitPlanet({
+        id: firstPlanetId,
+        name: 'NEW PLANET',
+        planetDetails,
+      });
 
       return {
         stellarStore: {
@@ -110,29 +165,11 @@ export const useStellarStore = create<StellarStore>((set, get) => ({
           updated_at: now,
           author_name: userName,
           creator_name: userName,
+          // 기존 로직 유지
           create_source_name: state.stellarStore.title,
           original_source_name: state.stellarStore.title,
-
-          star: {
-            ...(initialStellarStore.star as Star),
-            system_id: '',
-            properties: createRandomStarProperties(), // 랜덤
-            updated_at: now,
-          },
-          planets: [
-            {
-              id: newPlanetId,
-              object_type: 'PLANET',
-              system_id: '', // 아직 없을 수 있음
-              name: `NEW PLANET`,
-              role: 'DRUM',
-              properties: createRandomPlanetProperties(), // 랜덤
-              synthType: defaultSynth,
-              oscillatorType: getDefaultOscillatorType(role, defaultSynth),
-              created_at: formatDateToYMD(),
-              updated_at: formatDateToYMD(),
-            },
-          ],
+          star,
+          planets: [firstPlanet],
         },
       };
     }),
@@ -142,27 +179,21 @@ export const useStellarStore = create<StellarStore>((set, get) => ({
 
     set((state) => {
       const prev = state.stellarStore;
-      const role: InstrumentRole = 'DRUM';
-      const defaultSynth = getDefaultSynthType(role);
 
-      const newPlanet: Planet = {
+      // ✅ 요청: planetDetails 변수 사용 (랜덤 악기 구성)
+      const planetDetails = createRandomPlanetInstrument();
+      const newPlanet = makeInitPlanet({
         id: newPlanetId,
-        object_type: 'PLANET',
-        system_id: prev.id || '', // 아직 없을 수 있음
-        name: `NEW PLANET`,
-        role,
-        properties: createRandomPlanetProperties(), // 랜덤
-        synthType: defaultSynth,
-        oscillatorType: getDefaultOscillatorType(role, defaultSynth),
-        created_at: formatDateToYMD(),
-        updated_at: formatDateToYMD(),
-      };
+        systemId: prev.id || '',
+        name: 'NEW PLANET',
+        planetDetails,
+      });
 
       return {
         stellarStore: {
           ...prev,
           planets: [...prev.planets, newPlanet],
-          updated_at: formatDateToYMD(),
+          updated_at: nowYMD(),
         },
       };
     });
@@ -170,25 +201,18 @@ export const useStellarStore = create<StellarStore>((set, get) => ({
     return newPlanetId;
   },
 
-  // 행성 삭제
   deletePlanet: (planetId) => {
     const prev = get().stellarStore;
-    // const beforeLen = prev.planets.length;
     const nextPlanets = prev.planets.filter((p) => p.id !== planetId);
-
-    // 최소 1개의 PLANET이 있어야 함
-    if (nextPlanets.length === 0) {
-      return false;
-    }
+    if (nextPlanets.length === 0) return false; // 규칙 유지: 최소 1개 보장
 
     set({
       stellarStore: {
         ...prev,
         planets: nextPlanets,
-        updated_at: formatDateToYMD(),
+        updated_at: nowYMD(),
       },
     });
-
     return true;
   },
 }));

--- a/src/utils/randomPlanetDetails.ts
+++ b/src/utils/randomPlanetDetails.ts
@@ -1,0 +1,55 @@
+import {
+  getSynthProfilesForRole,
+  getAvailableOscillatorOptions,
+  getDefaultSynthType,
+  getDefaultOscillatorType,
+  type SynthTypeId,
+  type OscillatorTypeId,
+} from '@/audio/instruments/InstrumentInterface';
+import { type InstrumentRole } from '@/types/planetProperties';
+
+const ROLES: InstrumentRole[] = [
+  'DRUM',
+  'BASS',
+  'CHORD',
+  'MELODY',
+  'ARPEGGIO',
+  'PAD',
+];
+
+// 공용 랜덤 픽커
+function pickRandom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/**
+ * 행성의 PLANET DETAILS(역할/신스/오실레이터) 랜덤 생성
+ * - role 미지정 시 ROLES 중 임의 선택
+ * - role 기반으로 프로필 목록 → 신스 타입 랜덤
+ * - 프로필의 oscillatorSuggestions가 있으면 그 안에서, 없으면 전체 카탈로그에서 랜덤
+ * - 비어있을 경우 각 default*로 폴백
+ */
+export function createRandomPlanetInstrument(role?: InstrumentRole): {
+  role: InstrumentRole;
+  synthType: SynthTypeId;
+  oscillatorType: OscillatorTypeId;
+} {
+  const chosenRole = role ?? pickRandom(ROLES);
+
+  const profiles = getSynthProfilesForRole(chosenRole);
+  const synthType: SynthTypeId = profiles.length
+    ? (pickRandom(profiles).id as SynthTypeId)
+    : getDefaultSynthType(chosenRole);
+
+  const oscCatalog = getAvailableOscillatorOptions();
+  const preset = profiles.find((p) => p.id === synthType);
+  const candidateOscs = preset?.oscillatorSuggestions?.length
+    ? oscCatalog.filter((o) => preset!.oscillatorSuggestions!.includes(o.id))
+    : oscCatalog;
+
+  const oscillatorType: OscillatorTypeId = candidateOscs.length
+    ? (pickRandom(candidateOscs).id as OscillatorTypeId)
+    : getDefaultOscillatorType(chosenRole, synthType);
+
+  return { role: chosenRole, synthType, oscillatorType };
+}

--- a/src/utils/randomProperties.ts
+++ b/src/utils/randomProperties.ts
@@ -1,5 +1,5 @@
 // src/utils/randomProperties.ts
-import type { StarProperties } from '@/types/starProperties';
+import { STAR_PROPERTIES, type StarProperties } from '@/types/starProperties';
 import {
   PLANET_PROPERTIES,
   type PlanetProperties,
@@ -18,47 +18,27 @@ export function randStep(
   return precision != null ? +v.toFixed(precision) : v;
 }
 
-// Star용 정의(원하시면 별도 상수로 외부 분리 가능)
-const STAR_DEFS: Record<
-  keyof StarProperties,
-  { min: number; max: number; step?: number; precision?: number }
-> = {
-  spin: { min: 0, max: 100, step: 1 },
-  brightness: { min: 0, max: 100, step: 1 },
-  color: { min: 0, max: 360, step: 1 },
-  size: { min: 0.1, max: 2.0, step: 0.1, precision: 1 }, // 예: 소수1자리
-};
-
+/* =========================
+   STAR: 스키마 기반
+   ========================= */
 export function createRandomStarProperties(): StarProperties {
-  return {
-    spin: randStep(
-      STAR_DEFS.spin.min,
-      STAR_DEFS.spin.max,
-      STAR_DEFS.spin.step,
-      STAR_DEFS.spin.precision
-    ),
-    brightness: randStep(
-      STAR_DEFS.brightness.min,
-      STAR_DEFS.brightness.max,
-      STAR_DEFS.brightness.step,
-      STAR_DEFS.brightness.precision
-    ),
-    color: randStep(
-      STAR_DEFS.color.min,
-      STAR_DEFS.color.max,
-      STAR_DEFS.color.step,
-      STAR_DEFS.color.precision
-    ),
-    size: randStep(
-      STAR_DEFS.size.min,
-      STAR_DEFS.size.max,
-      STAR_DEFS.size.step,
-      STAR_DEFS.size.precision
-    ),
-  };
+  const out = {} as StarProperties;
+
+  (
+    Object.entries(STAR_PROPERTIES) as [
+      keyof StarProperties,
+      { min: number; max: number; step?: number }, // precision 없으면 생략
+    ][]
+  ).forEach(([key, def]) => {
+    (out as any)[key] = randStep(def.min, def.max, def.step ?? 1); // eslint-disable-line
+  });
+
+  return out;
 }
 
-// Planet용: PLANET_PROPERTIES 기반으로 전 필드 생성
+/* =========================
+   PLANET: 스키마 기반
+   ========================= */
 export function createRandomPlanetProperties(opts?: {
   clampInclination?: boolean;
 }): PlanetProperties {
@@ -79,6 +59,7 @@ export function createRandomPlanetProperties(opts?: {
       clampInclination && key === 'inclination'
         ? Math.min(def.max, 90)
         : def.max;
+
     (out as any)[key] = randStep(min, max, def.step ?? 1, def.precision); // eslint-disable-line
   });
 


### PR DESCRIPTION
## 작업 내용
- randomPlanetDetails.ts 유틸 추가: 행성의 역할/신스/오실레이터를 랜덤으로 생성
- useStellarStore 리팩터링
- 초기화/생성 시 헬퍼(makeInitStar, makeInitPlanet)로 STAR/PLANET 랜덤 프로퍼티와 랜덤 악기 상세 적용
- planetDetails 변수 사용으로 가독성과 재사용성 향상
- randomProperties.ts 개선: Star/Planet 랜덤 프로퍼티를 스키마(STAR_PROPERTIES, PLANET_PROPERTIES) 기반으로 생성하도록 변경

## 참고 사항
- 레거시 데이터에 synthType/oscillatorType이 비어 있을 수 있으니 optional 유지 권장(필수화 시 마이그레이션 필요)
- 랜덤 정책(역할 가중치/오실레이터 제약 등) 변경 시 randomPlanetDetails.ts만 수정하면 반영됨
- 파일 경로/이름(createPlanetId 등) 통일 여부 확인 필요