### PR TITLE
[리팩토링] Main컴포넌트 section 타입 구조 개선 & user profile 쿼리 키 수정

### DIFF
--- a/src/components/main/canvas/MainCanvas.tsx
+++ b/src/components/main/canvas/MainCanvas.tsx
@@ -16,42 +16,23 @@ export default function MainCanvas({
 }: MainCanvasProps) {
   // #0c0f13 이전 배경색
   return (
-    <>
-      {/* 로딩 화면 */}
-      {isLoading && (
-        <div className="block w-full fixed top-0 left-0 right-0 bottom-0 z-0 h-screen bg-[#000000]">
-          <Canvas
-            linear
-            dpr={[1, 2]}
-            orthographic
-            camera={{ zoom: mainStore.zoom, position: [0, 0, 500] }}
-          >
-            {/* 로딩 컴포넌트만 렌더링 */}
-            <Loading setIsLoading={setIsLoading} />
-          </Canvas>
-        </div>
-      )}
-
-      {/* 3D Canvas */}
-      {!isLoading && (
-        <div className="block w-full fixed top-0 left-0 right-0 bottom-0 z-0 h-screen bg-[#000000]">
-          <Canvas
-            linear
-            dpr={[1, 2]}
-            orthographic
-            camera={{ zoom: mainStore.zoom, position: [0, 0, 500] }}
-          >
-            {/* 별모임 - 전체 배경으로 항상 보임 */}
+    <div className="block w-full fixed top-0 left-0 right-0 bottom-0 z-0 h-screen bg-[#000000]">
+      <Canvas
+        linear
+        dpr={[1, 2]}
+        orthographic
+        camera={{ zoom: mainStore.zoom, position: [0, 0, 500] }}
+      >
+        {isLoading ? (
+          <Loading setIsLoading={setIsLoading} />
+        ) : (
+          <>
             <Stars />
-
-            {/* 카메라 제어 */}
             <CameraRig zStart={10} zEnd={3} />
-
-            {/* 3D 콘텐츠 */}
             <Content />
-          </Canvas>
-        </div>
-      )}
-    </>
+          </>
+        )}
+      </Canvas>
+    </div>
   );
 }

--- a/src/components/main/scroll/SectionsList.tsx
+++ b/src/components/main/scroll/SectionsList.tsx
@@ -17,9 +17,9 @@ export default function SectionsList() {
             return (
               <TextSection
                 key={`text-${index}`}
-                title={section.title!}
-                description={section.description!}
-                alignment={section.alignment!}
+                title={section.title}
+                description={section.description}
+                alignment={section.alignment}
               />
             );
 

--- a/src/components/main/sections/index.ts
+++ b/src/components/main/sections/index.ts
@@ -3,12 +3,15 @@ export { default as TextSection } from './TextSection';
 export { default as CTASection } from './CTASection';
 
 // 섹션 데이터 정의
-export interface SectionData {
-  type: 'intro' | 'text' | 'cta';
-  title?: string;
-  description?: string;
-  alignment?: 'left' | 'center' | 'right';
-}
+export type SectionData =
+  | { type: 'intro' }
+  | {
+      type: 'text';
+      title: string;
+      description: string;
+      alignment: 'left' | 'center' | 'right';
+    }
+  | { type: 'cta' };
 
 export const mainSections: SectionData[] = [
   { type: 'intro' },

--- a/src/components/panel/galaxy/community/List.tsx
+++ b/src/components/panel/galaxy/community/List.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from 'react';
+import { Suspense } from 'react';
 import { useGetStellarList } from '@/hooks/api/useGalaxy';
 import CardItem from './CardItem';
 import {
@@ -36,7 +36,6 @@ export default function List({ sort }: { sort: SortLabel }) {
 function ContentComp({ sort }: { sort: SortLabel }) {
   const { selectStellar } = useStellarSystemSelection();
 
-  useEffect(() => {}, [sort]);
   // 갤럭시 리스트 데이터
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGetStellarList({

--- a/src/hooks/api/queryKeys/followKeys.ts
+++ b/src/hooks/api/queryKeys/followKeys.ts
@@ -1,7 +1,6 @@
 // useFollow.ts의 쿼리키 모음
 export const followKeys = {
   all: ['follow'] as const,
-  userProfile: (userId: string) => ['userProfile', userId] as const,
   followings: (userId: string) => ['followings', userId] as const,
   followers: (userId: string) => ['followers', userId] as const,
   followCount: (userId: string) => ['followCount', userId] as const,

--- a/src/hooks/api/useFollow.ts
+++ b/src/hooks/api/useFollow.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/types/follow';
 import type { AxiosError } from 'axios';
 import { followKeys } from './queryKeys/followKeys';
+import { userKeys } from './queryKeys/userKeys';
 
 // 팔로우 생성
 export function useCreateFollow() {
@@ -30,7 +31,7 @@ export function useCreateFollow() {
 
       // 내 프로필과 팔로잉 목록 무효화
       queryClient.invalidateQueries({
-        queryKey: followKeys.userProfile(myUserId),
+        queryKey: userKeys.userProfile(myUserId),
       });
       queryClient.invalidateQueries({
         queryKey: followKeys.followings(myUserId),
@@ -44,7 +45,7 @@ export function useCreateFollow() {
         queryKey: followKeys.followCount(targetUserId),
       });
       queryClient.invalidateQueries({
-        queryKey: followKeys.userProfile(targetUserId),
+        queryKey: userKeys.userProfile(targetUserId),
       });
     },
     onError: (error: AxiosError) => {
@@ -72,7 +73,7 @@ export function useDeleteFollow() {
 
       // 내 프로필과 팔로잉 목록 무효화
       queryClient.invalidateQueries({
-        queryKey: followKeys.userProfile(myUserId),
+        queryKey: userKeys.userProfile(myUserId),
       });
       queryClient.invalidateQueries({
         queryKey: followKeys.followings(myUserId),
@@ -86,7 +87,7 @@ export function useDeleteFollow() {
         queryKey: followKeys.followCount(targetUserId),
       });
       queryClient.invalidateQueries({
-        queryKey: followKeys.userProfile(targetUserId),
+        queryKey: userKeys.userProfile(targetUserId),
       });
     },
     onError: (error: AxiosError) => {

--- a/src/hooks/api/useUser.ts
+++ b/src/hooks/api/useUser.ts
@@ -70,7 +70,7 @@ export function useUpdateUserProfile() {
 
       // 모든 userProfile 관련 쿼리 무효화
       queryClient.invalidateQueries({
-        queryKey: userKeys.all,
+        queryKey: userKeys.userProfile(updatedUser.id),
       });
     },
     onError: (error: AxiosError) => {


### PR DESCRIPTION
## 작업 내용
- SectionData를 **판별식 유니온(discriminated unions)**으로 리팩터링하여 타입 안정성 강화
- SectionsList의 불필요한 non-null 단언 제거
- follow/user 훅에서 followKeys.userProfile → userKeys.userProfile로 교체
- followKeys의 미사용 userProfile 키 제거
- 커뮤니티 List 컴포넌트의 미사용 useEffect 제거

## 참고 사항
- 쿼리 키 네임스페이스 변경으로 invalidateQueries/refetchQueries 호출부의 키 확인 필요
- SectionData 타입 변경으로 스위치/가드 누락 시 컴파일 오류가 발생할 수 있음(의도된 안전장치)
- 쿼리 키 변경에 따라 최초 마운트 시 재패치가 발생할 수 있음