### PR TITLE
[수정] TextType컴포넌트 and breadcrumb컴포넌트 null 핸들링

### DIFF
--- a/src/components/main/ui/TextType.tsx
+++ b/src/components/main/ui/TextType.tsx
@@ -147,7 +147,7 @@ const TextType = ({
           setCurrentCharIndex(0);
 
           // 다음 문장 타이핑 전 대기
-          timeout = setTimeout(() => {}, pauseDuration);
+          timeout = setTimeout(executeTypingAnimation, pauseDuration);
         } else {
           // 한 글자씩 지우기
           timeout = setTimeout(() => {

--- a/src/components/panel/stellar/breadcrumb/Breadcrumb.tsx
+++ b/src/components/panel/stellar/breadcrumb/Breadcrumb.tsx
@@ -5,7 +5,7 @@ import { getObjectNameById } from '@/utils/getObjectName';
 export default function Breadcrumb() {
   const { stellarStore } = useStellarStore();
   const { selectedObjectId } = useSelectedObjectStore();
-  const selectedObjectName = getObjectNameById(selectedObjectId);
+  const selectedObjectName = getObjectNameById(selectedObjectId) ?? '';
   const selectedStellarTitle = stellarStore.title;
 
   return (


### PR DESCRIPTION
## 작업 내용
- TextType에서 일시정지 후 executeTypingAnimation 호출로 타이핑 애니메이션이 정상 재개되도록 수정
- Breadcrumb에서 selectedObjectName이 null 또는 undefined일 경우 빈 문자열을 표시하도록 처리

## 참고 사항
- Breadcrumb 표시 로직 변경으로 null/undefined 상태에서도 UI 깨짐 없음