### PR TITLE
[리팩토링] ProfilePanel 컴포넌트에 Suspense 로 에러 캐치 설정

### DIFF
--- a/src/components/layout/Sidebar/SidebarPanel/Profile/ProfilePanel.tsx
+++ b/src/components/layout/Sidebar/SidebarPanel/Profile/ProfilePanel.tsx
@@ -1,5 +1,12 @@
+// ProfilePanel.tsx
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import axios from 'axios';
+
 import { useUserStore } from '@/stores/useUserStore';
 import { useProfileStore } from '@/stores/useProfileStore';
+
 import LoginPanel from './LoginPanel';
 import SignUpPanel from './SignUpPanel';
 import ProfileView from './ProfileView';
@@ -9,13 +16,53 @@ import LikesPanel from './LikesPanel';
 import FollowersPanel from './FollowersPanel';
 import FollowingsPanel from './FollowingsPanel';
 
+// 1) 에러 fallback 컴포넌트
+function ProfileErrorFallback({
+  error,
+  resetErrorBoundary,
+}: {
+  error: unknown;
+  resetErrorBoundary: () => void;
+}) {
+  // 401 등 인증 관련
+  if (axios.isAxiosError(error) && error.response?.status === 401) {
+    return (
+      <div className="h-full flex flex-col">
+        {/* 로그인 유도 UI로 바로 분기 */}
+        <LoginPanel />
+        <button className="mt-4 self-start" onClick={resetErrorBoundary}>
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  // 그 외 일반 에러
+  return (
+    <div className="p-4">
+      <p className="font-semibold">프로필 패널 로딩 중 오류가 발생했습니다.</p>
+      <pre className="mt-2 text-xs opacity-70 overflow-auto max-h-40">
+        {String(error)}
+      </pre>
+      <button className="mt-4" onClick={resetErrorBoundary}>
+        다시 시도
+      </button>
+    </div>
+  );
+}
+
+// 2) 로딩 fallback (Suspense용)
+function ProfileSkeleton() {
+  return <div className="p-4">프로필 패널을 불러오는 중…</div>;
+}
+
 export default function ProfilePanel() {
   const { isLoggedIn } = useUserStore();
   const { profilePanelMode, viewingUserId } = useProfileStore();
+  const { reset } = useQueryErrorResetBoundary(); // ErrorBoundary가 reset될 때 쿼리 에러도 함께 리셋
 
   const renderContent = () => {
     if (!isLoggedIn) {
-      // 로그인되지 않은 상태
       switch (profilePanelMode) {
         case 'signup':
           return <SignUpPanel />;
@@ -24,7 +71,6 @@ export default function ProfilePanel() {
       }
     }
 
-    // 로그인된 상태
     switch (profilePanelMode) {
       case 'otherUserProfile':
         return viewingUserId ? (
@@ -50,8 +96,17 @@ export default function ProfilePanel() {
   };
 
   return (
-    <div className="h-full flex flex-col overflow-hidden">
-      {renderContent()}
-    </div>
+    <ErrorBoundary
+      // 라우트/모드/대상 변경 시 에러 경계 리셋
+      resetKeys={[isLoggedIn, profilePanelMode, viewingUserId]}
+      onReset={reset} // React Query 쪽 에러 상태도 함께 초기화
+      fallbackRender={ProfileErrorFallback}
+    >
+      <Suspense fallback={<ProfileSkeleton />}>
+        <div className="h-full flex flex-col overflow-hidden">
+          {renderContent()}
+        </div>
+      </Suspense>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## 작업 내용
* ProfilePanel 내용을 ErrorBoundary와 Suspense로 감싸 에러 및 로딩 상태를 일괄 처리
* 에러 및 로딩 상황에 맞는 커스텀 fallback 컴포넌트 추가
* 인증 에러(401)에 대한 별도 처리 로직 구현
* useQueryErrorResetBoundary를 연동하여 ErrorBoundary 리셋 시 React Query 에러 상태도 초기화

## 참고 사항
* 기존에는 쿼리 에러 발생 시 라우트 전역 에러 화면으로 전파되던 문제를 방지
* 추후 다른 패널 컴포넌트에서도 동일한 경계 패턴을 재사용 가능